### PR TITLE
VOTE: License exemption for OQS-BoringSSL

### DIFF
--- a/governance/approved_licenses.md
+++ b/governance/approved_licenses.md
@@ -1,0 +1,11 @@
+# Approved licenses
+
+The [OQS Technical Charter](https://github.com/open-quantum-safe/tsc/blob/main/charter/) section 7.a.i specifies that all inbound and outbound code contributions to the Project must be made using the MIT License.  
+
+Section 7.c permits the TSC to approve the use of an alternative license for inbound or outbound contributions on an exception basis.
+
+This document records license exemptions approved by the OQS TSC.
+
+### OQS-BoringSSL
+
+Contributions to the repository [open-quantum-safe/boringssl](https://github.com/open-quantum-safe/boringssl/) can be made using the [LICENSE file included in that repository](https://github.com/open-quantum-safe/boringssl/blob/master/LICENSE).


### PR DESCRIPTION
The [OQS Technical Charter](https://github.com/open-quantum-safe/tsc/blob/main/charter/) section 7.a.i specifies that all inbound and outbound code contributions to the Project must be made using the MIT License.  

Section 7.c permits the TSC to approve the use of an alternative license for inbound or outbound contributions on an exception basis.

This pull request creates a file in the tsc repository tracking the list of approved license exemptions and grants an exemption to contribute code to the open-quantum-safe/boringssl repository using the licenses in the LICENSE file contained in that repository.  

Partially fixes #13.

I've submitted this as a draft pull request for now to get feedback on whether this is an agreeable approach; @hartm what do you think? If it seems okay, then I'll remove draft status and ask for a vote, in which TSC members would "vote" by approving the PR.  Note that the charter requires that license amendments pass with a 2/3 vote.  We have 8 members, so that would require 6 votes in favour.