### PR TITLE
Add link to minutes and basic index

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The role and responsibilities of the TSC are described in the [Technical Charter
 
 ## Communication Channels
 
+### Meetings
+
+The TSC holds regular meetings. [agenda and minutes](meetings/index.md)
+
 ### Email list
 
 Public mailing list for the OQS TSC: [oqs-tsc@lists.pqca.org](mailto:oqs-tsc@lists.pqca.org)

--- a/meetings/index.md
+++ b/meetings/index.md
@@ -1,0 +1,12 @@
+# Open Quantum Safe TSC Meetings
+
+Meetings are held approximately monthly.
+
+# Who Can Attend
+
+Everyone, regardless of membership within the TSC itself, is welcome to attend. 
+
+# Meeting Agenda and Minutes
+
+- 2024-04-10 [agenda](2024-04-10/agenda.md) / [minutes](2024-04-10/minutes.md)
+- 2024-03-11 [agenda](2024-03-11/agenda.md) / [minutes](2024-03-11/minutes.md)


### PR DESCRIPTION
This PR adds a simple link on the front page to a minutes & agenda page
That page then provides links to the agenda and minutes of each meeting (latest first)

We may want to adopt more sophisticated layout, but this could be a first step.

NOTE: This does include links to files that are currently in review but felt it better to separate this proposal from the review of the minutes themselves 