### PR TITLE
Remove Amber Sprenkels from liboqs-rust

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -81,7 +81,6 @@ repositories:
   visibility: public
 - name: liboqs-rust
   collaborators:
-    dsprenkels: write
     thomwiggers: admin
   teams:
     core: write


### PR DESCRIPTION
Amber Sprenkels @dsprenkels had been contributing to the liboqs-rust repository but is not able to actively help out at this time, so we can remove her for now and add her back if she becomes more available to help.