### PR TITLE
Add agendas and minutes from OQS weekly status meetings from 2024

### DIFF
--- a/oqs-status-meetings/2024-01-02 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-01-02 - OQS status meeting - agenda.md
@@ -1,0 +1,255 @@
+# 2024-01-02 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday January 02 at 12:30 PM </span> US Eastern Time / 6:30 PM Central European / 9:30 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+2. liboqs 0.9.2 release planning
+3. API structure - internal / SHA-3
+
+## OQS subprojects
+
+1. liboqs
+2. OQS-OpenSSL 3 provider
+3. OQS-BoringSSL
+4. OQS-OpenSSH
+5. OQS-libssh
+6. oqs-demos
+7. profiling
+8. ci-containers
+9. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+10. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1636: Apply patch to Kyber aarch64 code from PQClean for variable-time division issue.
+	- Open PRs:
+		 - PR 1560: Test against all 100 KAT values
+		 - PR 1603: Make common algorithms implementation pluggable
+		 - PR 1626: Add ML-DSA-ipd and ML-KEM-ipd & NIST supplied test vectors
+		 - PR 1632: Fix BIKE constant-time errors
+		 - PR 1641: Riscv zephyr support
+		 - PR 1643: Correct cmake version requirement
+	- Open Issues:
+		 - Issue 1645: Further Kyber division fixes
+		 - Issue 1642: Objects of target "oqs" referenced but is not an OBJECT library.
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1634: Fix windows-x86 and arm compiling error.
+		 - Issue 1630: Improve CI for macOS on Apple Silicon
+		 - Issue 1624: BIKE constant time tests failing
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1617: Falcon constant time tests failing
+		 - Issue 1608: Support multiple Falcon signature formats
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1599: Make low-level crypto algorithms implementation switchable
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1591: Falcon variable length signatures 
+		 - Issue 1573: ARM build fails with `-DOQS\_DIST\_BUILD=OFF` on CircleCI
+		 - Issue 1564: Update README and other documentation to better describe algorithm status
+		 - Issue 1561: Falcon-1024 KATs differ from upstream
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1539: Update OpenSSL integration
+		 - Issue 1521: Update Kyber and Dilithium to FIPS versions
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1490: Add option to exclude the compilation of OQS\_randombytes\_system() when a custom algorithm is specified
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1443: OQS\_ENABLE\_KEM\_BIKE forced to OFF for ARCH\_X86
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1418: Expand test coverage to all 100 NIST KAT values
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Wrong flag passed to Clang when memory sanitizer build is requested.
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 1072: Android Buildscript problem with Cross Compilation
+		 - Issue 910: Establish interop with Circl
+		 - Issue 594: Add options for iOS and Android cross-compilation
+		 - Issue 167: Code coverage
+
+
+2. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 325: Revert "Use `build` directory instead of `\_build`. (#314)"
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 317: Implementation of Composite Sig
+		 - PR 327: reverting to dev
+	- Open Issues:
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 318: commit f205f116 broke tests
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+3. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+4. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+5. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+6. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 220: Update unbound DNS for openssl 3.x.x
+		 - PR 249: Renaming nginx/fulltest-provider -> nginx/fulltest & delete old fulltest dir.
+	- Open Issues:
+		 - Issue 253: https://test.openquantumsafe.org:6000 does not accept `x25519\_kyber768`
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+7. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+8. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+9. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 34: How to use x509 Certificate Signer on golang
+		 - Issue 25: Link liboqs statically
+
+
+12. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+13. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 57: Question: Worth while automating install?
+
+
+14. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+15. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-01-02 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-01-02 - OQS status meeting - minutes.md
@@ -1,0 +1,95 @@
+# 2024-01-02 - OQS status meeting - minutes
+
+*Attendees: Christian (MSR); Douglas, Eddy, Pravek, Spencer (UW); Eric (AWS); Mark (Cisco); Michael; Sara (Synopsys); Vlad (softwareQ)*
+
+<!--### Next meeting: Tuesday January 2, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+### Next meeting: Tuesday January 9 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+2. liboqs 0.9.2 release planning
+3. API structure - internal / SHA-3
+
+## 1. Status updates
+
+### liboqs
+
+Updated constant-time suppression files for Falcon and BIKE have landed.
+
+PR #1643 needs review.
+
+Michael notes a problem between liboqs 0.9.1 release and oqs-provider related to HQC; oqs-provider failed because stuff didn't get cherry-picked over properly and tests (oqs-provider release-test scripts) weren't run on the downstream oqs-provider before liboqs release.  Should be added to release process page on OQS wiki.
+
+### OpenSSL 3 Provider
+
+A 0.5.3 release is waiting to sync with 0.9.1.  Should it be released, or wait until 0.9.2?  Decision is to wait until 0.9.2.
+
+There was an issue asking why we used SHA-384 in a hashing the hybrid signature between Dilithium2 and ecdsap256.  Douglas says he doesn't know why.
+
+### BoringSSL
+
+No updates.
+
+### OpenSSH and libssh
+
+No updates.
+
+### OQS-Demos
+
+No updates.
+
+### Profiling
+
+No updates.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+No updates.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+No updates.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.
+
+## 2. liboqs 0.9.2 release
+
+This would address additional Kyber potentially non-constant-time divisions.  
+
+Spencer and Pravek will help pulling in the code updates needed.  Goal is to have a release candidate by end of week and then do the release early next week.
+
+Douglas to create a branch for this security release.
+
+Michael to highlight the commit needed to be cherry-picked over to avoid problems with oqs-provider.
+
+## 3. API structure - internal / SHA-3
+
+Spencer asks whether our API especially around SHA-3 is being exposed the way we intend.  He noticed that sha3.h is being installed in the include/oqs directory and that some functions are available in test programs.  Douglas says that for the header file, it could just be a mistake in the CMake configuration.
+
+## 4. Other business
+
+Christian reports that the NCCoE has released some reports for which they are seeking feedback:
+
+https://www.nccoe.nist.gov/crypto-agility-considerations-migrating-post-quantum-cryptographic-algorithms
+
+

--- a/oqs-status-meetings/2024-01-09 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-01-09 - OQS status meeting - agenda.md
@@ -1,0 +1,262 @@
+# 2024-01-09 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday January 09 at 10:00 AM </span> US Eastern Time / 4:00 PM Central European / 7:00 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+
+## OQS subprojects
+
+1. liboqs
+2. OQS-OpenSSL 3 provider
+3. OQS-BoringSSL
+4. OQS-OpenSSH
+5. OQS-libssh
+6. oqs-demos
+7. profiling
+8. ci-containers
+9. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+10. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1632: Fix BIKE constant-time errors
+		 - PR 1646: Fix falcon constant time check in Valgrind
+		 - PR 1634: Fix windows-x86 and arm compiling error.
+		 - PR 1643: Correct cmake version requirement
+		 - PR 1652: Pull Kyber division fixes from PQ-Crystals into dev-092
+		 - PR 1649: Pull Kyber division fixes from PQ-Crystals into main
+	- Open PRs:
+		 - PR 1560: Test against all 100 KAT values
+		 - PR 1603: Make common algorithms implementation pluggable
+		 - PR 1626: Add ML-DSA-ipd and ML-KEM-ipd & NIST supplied test vectors
+		 - PR 1641: Riscv zephyr support
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1653: find\_package(Threads) regardless of BUILD\_ONLY\_LIB
+		 - PR 1654: Run oqs-provider release tests in CI on release candidate branches
+	- Open Issues:
+		 - Issue 1656: Address  stateful-sigs comments in #1650
+		 - Issue 1655: Update `sig\_stfl.h` document for #1650
+		 - Issue 1648: Better separate internal and public APIs
+		 - Issue 1647: (Automated) downstream release testing
+		 - Issue 1642: Objects of target "oqs" referenced but is not an OBJECT library.
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1630: Improve CI for macOS on Apple Silicon
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1608: Support multiple Falcon signature formats
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1599: Make low-level crypto algorithms implementation switchable
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1591: Falcon variable length signatures 
+		 - Issue 1573: ARM build fails with `-DOQS\_DIST\_BUILD=OFF` on CircleCI
+		 - Issue 1564: Update README and other documentation to better describe algorithm status
+		 - Issue 1561: Falcon-1024 KATs differ from upstream
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1539: Update OpenSSL integration
+		 - Issue 1521: Update Kyber and Dilithium to FIPS versions
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1490: Add option to exclude the compilation of OQS\_randombytes\_system() when a custom algorithm is specified
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1443: OQS\_ENABLE\_KEM\_BIKE forced to OFF for ARCH\_X86
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1418: Expand test coverage to all 100 NIST KAT values
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Wrong flag passed to Clang when memory sanitizer build is requested.
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 1072: Android Buildscript problem with Cross Compilation
+		 - Issue 910: Establish interop with Circl
+		 - Issue 594: Add options for iOS and Android cross-compilation
+		 - Issue 167: Code coverage
+
+
+2. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 327: reverting to dev
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 317: Implementation of Composite Sig
+	- Open Issues:
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 318: commit f205f116 broke tests
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+3. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+4. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 154: OQS SSH Key Signing for PKI fails with quantum-resistant algorithms
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+5. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+6. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 220: Update unbound DNS for openssl 3.x.x
+		 - PR 249: Renaming nginx/fulltest-provider -> nginx/fulltest & delete old fulltest dir.
+	- Open Issues:
+		 - Issue 253: https://test.openquantumsafe.org:6000 does not accept `x25519\_kyber768`
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+7. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+8. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+9. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 34: How to use x509 Certificate Signer on golang
+		 - Issue 25: Link liboqs statically
+
+
+12. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+13. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 72: Criptomoneda
+		 - Issue 57: Question: Worth while automating install?
+
+
+14. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+15. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-01-16 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-01-16 - OQS status meeting - agenda.md
@@ -1,0 +1,267 @@
+# 2024-01-16 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday January 16 at 12:30 PM </span> US Eastern Time / 6:30 PM Central European / 9:30 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+2. liboqs 0.9.2 release
+3. Maintainer for liboqs-Rust
+4. Safety of stateful hash-based signature API
+
+## OQS subprojects
+
+1. liboqs
+2. OQS-OpenSSL 3 provider
+3. OQS-BoringSSL
+4. OQS-OpenSSH
+5. OQS-libssh
+6. oqs-demos
+7. profiling
+8. ci-containers
+9. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+10. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1656: Address  stateful-sigs comments in #1650
+		 - PR 1659: Bump gitpython from 3.1.37 to 3.1.41 in /scripts/copy\_from\_upstream
+		 - PR 1655: Update `sig\_stfl.h` document for #1650
+		 - PR 1658: Zephyr: fixes for platform support
+		 - PR 1661: Bump jinja2 from 2.11.3 to 3.1.3 in /scripts/copy\_from\_upstream
+		 - PR 1641: Riscv zephyr support
+	- Open PRs:
+		 - PR 1560: Test against all 100 KAT values
+		 - PR 1603: Make common algorithms implementation pluggable
+		 - PR 1626: Add ML-DSA-ipd and ML-KEM-ipd & NIST supplied test vectors
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1653: find\_package(Threads) regardless of BUILD\_ONLY\_LIB
+		 - PR 1654: Run oqs-provider release tests in CI on release candidate branches
+		 - PR 1664: Zephyr: CMake fixes
+	- Open Issues:
+		 - Issue 1663: Update documentation and license text.
+		 - Issue 1662: Add Apache 2.0 and MIT License to XMSS
+		 - Issue 1648: Better separate internal and public APIs
+		 - Issue 1647: (Automated) downstream release testing
+		 - Issue 1642: Objects of target "oqs" referenced but is not an OBJECT library.
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1630: Improve CI for macOS on Apple Silicon
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1608: Support multiple Falcon signature formats
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1599: Make low-level crypto algorithms implementation switchable
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1591: Falcon variable length signatures 
+		 - Issue 1573: ARM build fails with `-DOQS\_DIST\_BUILD=OFF` on CircleCI
+		 - Issue 1564: Update README and other documentation to better describe algorithm status
+		 - Issue 1561: Falcon-1024 KATs differ from upstream
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1539: Update OpenSSL integration
+		 - Issue 1521: Update Kyber and Dilithium to FIPS versions
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1490: Add option to exclude the compilation of OQS\_randombytes\_system() when a custom algorithm is specified
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1443: OQS\_ENABLE\_KEM\_BIKE forced to OFF for ARCH\_X86
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1418: Expand test coverage to all 100 NIST KAT values
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Wrong flag passed to Clang when memory sanitizer build is requested.
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 1072: Android Buildscript problem with Cross Compilation
+		 - Issue 910: Establish interop with Circl
+		 - Issue 594: Add options for iOS and Android cross-compilation
+		 - Issue 167: Code coverage
+
+
+2. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 317: Implementation of Composite Sig
+		 - PR 334: Bump jinja2 from 3.0.3 to 3.1.3 in /oqs-template
+	- Open Issues:
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 318: commit f205f116 broke tests
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+3. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+4. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 154: OQS SSH Key Signing for PKI fails with quantum-resistant algorithms
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+5. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+6. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 220: Update unbound DNS for openssl 3.x.x
+		 - PR 249: Renaming nginx/fulltest-provider -> nginx/fulltest & delete old fulltest dir.
+	- Open Issues:
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 253: https://test.openquantumsafe.org:6000 does not accept `x25519\_kyber768`
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+7. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+8. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+9. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 34: How to use x509 Certificate Signer on golang
+		 - Issue 25: Link liboqs statically
+
+
+12. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+13. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 72: Criptomoneda
+		 - Issue 57: Question: Worth while automating install?
+
+
+14. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+15. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-01-16 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-01-16 - OQS status meeting - minutes.md
@@ -1,0 +1,98 @@
+# 2024-01-16 - OQS status meeting - minutes
+
+*Attendees: Alex, Mark, Norm (Cisco); Christian (MSR); Douglas, Pravek, Spencer (UW); Eric (AWS); Jason (SandboxAQ); Michael; Sara (Synopsys); Vlad (softwareQ)*
+
+<!--### Next meeting: Tuesday January 2, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+### Next meeting: Tuesday January 23 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+2. liboqs 0.9.2 release
+3. Maintainer for liboqs-Rust
+4. Safety of stateful hash-based signature API
+
+## 1. Status updates
+
+### liboqs
+
+No updates.
+
+### OpenSSL 3 Provider
+
+No updates.
+
+### BoringSSL
+
+No updates.
+
+### OpenSSH and libssh
+
+Should we label OpenSSH as less supported / deprecated? Christian does not have bandwidth to do major updates like in the past.  Michael notes that the falcosecurity organization on Github has some promising documents on denoting project lifecycle.
+
+### OQS-Demos
+
+Christian reports that in the NCCoE, Palo Alto Networks wants to start doing some VPN testing.  Do we have any IPsec demos?  No, only OpenVPN, which is TLS-based.
+
+### Profiling
+
+No updates.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+Vlad has a fix for issue #25.  Will release a version matching liboqs 0.9.2 later this week.  Regarding the X.509 issue #34, is this in scope of liboqs-go?  No, seems to be about higher level APIs in Go which are not part of the liboqs language wrapper.  Vlad to respond that it's out of scope then close.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+Vlad has a fix coming for issue #57 which will install liboqs if it's not found.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.
+
+## 2. liboqs 0.9.2 release
+
+Douglas asks for feedback on the 0.9.2 release candidate.  
+
+Michael created a branch in oqs-provider testing 0.9.2 and everything was fine, so okay to go there.
+
+Spencer ran the release test script for 0.9.2 and it ran fine.  Spencer also ran the constant time tests.  With extensions enabled, everything passed.  With extensions disabled, there were some failures but not in Kyber; Spencer will create an issue to track this but we won't hold the 0.9.2 release for it since it's not related.
+
+Michael asks what else should be released as part of the 0.9.2 release cycle.
+
+- Demos: Normally we do a release tag matching liboqs but the process for generating those builds off of liboqs main; would need to update to build off of a specific tag.  Michael to see how difficult this would be.
+- Test server needs to be updated.  Douglas to create an issue and tag Basil.
+
+Consensus: okay for 0.9.2 release. Douglas to release later today.
+
+## 3. Maintainer for liboqs-Rust
+
+After several years of excellent service, Thom is stepping down as maintainer of liboqs-rust.  Vlad has some Rust experience and offers to help maintain, Jason offers as well.  
+
+## 4. Safety of stateful hash-based signature API
+
+Comments were raised today on liboqs PR #1650 with concerns about whether it is safe to make available software-based implementation of stateful hash-based signature schemes.
+
+- Jason thinks it's okay to include in an experimental library -- people want to do experiments. Could rip it out later once we move to production oriented.
+- Michael suggests putting it into a separate repository especially since it uses a distinct API from normal signatures.
+- Spencer suggests that configuration time flags could be used to turn on/off the key generation and signing. Norm had been considering adding configuration time flags later, but maybe we have to do it sooner rather than later.
+- Douglas to think about who else we could ask for an opinion.  Norm notes that Scott Fluhrer has in the past been in agreement with NIST guidance and against having these operations in software.
+
+Norm to look at what it would take to sequester signing and key generation at configuration time. 

--- a/oqs-status-meetings/2024-01-23 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-01-23 - OQS status meeting - agenda.md
@@ -1,0 +1,276 @@
+# 2024-01-23 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday January 23 at 10:00 AM </span> US Eastern Time / 4:00 PM Central European / 7:00 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+2. liboqs 0.10.0 release planning
+3. Linux Foundation update
+
+## OQS subprojects
+
+1. liboqs
+2. OQS-OpenSSL 3 provider
+3. OQS-BoringSSL
+4. OQS-OpenSSH
+5. OQS-libssh
+6. oqs-demos
+7. profiling
+8. ci-containers
+9. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+10. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1664: Zephyr: CMake fixes
+		 - PR 1663: Update documentation and license text.
+		 - PR 1662: Add Apache 2.0 and MIT License to XMSS
+		 - PR 1668: Clarify that copyright is held by authors and not the project itself [skip ci]
+		 - PR 1667: Make internal API available to (only) test programs
+		 - PR 1669: Remove reference to old BIKE variants from CONFIGURE.md [skip ci]
+		 - PR 1670: Suggestions to governance document
+	- Open PRs:
+		 - PR 1560: Test against all 100 KAT values
+		 - PR 1603: Make common algorithms implementation pluggable
+		 - PR 1626: Add ML-DSA-ipd and ML-KEM-ipd & NIST supplied test vectors
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1653: find\_package(Threads) regardless of BUILD\_ONLY\_LIB
+		 - PR 1654: Run oqs-provider release tests in CI on release candidate branches
+		 - PR 1671: Call set\_available\_cpu\_extensions using pthread\_once
+		 - PR 1675: Add a document describing our subproject governance
+	- Open Issues:
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1666: Update constant-time suppression files for Sphincs+ and McEliece generic configuration
+		 - Issue 1647: (Automated) downstream release testing
+		 - Issue 1642: Objects of target "oqs" referenced but is not an OBJECT library.
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1630: Improve CI for macOS on Apple Silicon
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1608: Support multiple Falcon signature formats
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1599: Make low-level crypto algorithms implementation switchable
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1591: Falcon variable length signatures 
+		 - Issue 1573: ARM build fails with `-DOQS\_DIST\_BUILD=OFF` on CircleCI
+		 - Issue 1564: Update README and other documentation to better describe algorithm status
+		 - Issue 1561: Falcon-1024 KATs differ from upstream
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1539: Update OpenSSL integration
+		 - Issue 1521: Update Kyber and Dilithium to FIPS versions
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1490: Add option to exclude the compilation of OQS\_randombytes\_system() when a custom algorithm is specified
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1443: OQS\_ENABLE\_KEM\_BIKE forced to OFF for ARCH\_X86
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1418: Expand test coverage to all 100 NIST KAT values
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Wrong flag passed to Clang when memory sanitizer build is requested.
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 1072: Android Buildscript problem with Cross Compilation
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+2. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 334: Bump jinja2 from 3.0.3 to 3.1.3 in /oqs-template
+		 - PR 337: update to 0.5.4-dev
+		 - PR 336: LICENSE copyright update [skip ci]
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 317: Implementation of Composite Sig
+	- Open Issues:
+		 - Issue 340: on replacing a pqc algorithm with a custom implementation
+		 - Issue 339: .deb inside of oqsprovider-linux-x64.zip 0.5.3 does not work & prevents OpenSSL from loading
+		 - Issue 338: oqsprovider-linux-aarch64.zip 0.5.3, the .deb incorrectly identifies as AMD64
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 318: commit f205f116 broke tests
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+3. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+4. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 154: OQS SSH Key Signing for PKI fails with quantum-resistant algorithms
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+5. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+6. **oqs-demos**
+
+
+	- Merges in the last 7 days:
+		 - PR 259: document KEX=* semantics
+		 - PR 258: Fix broken relative link in nginx/fulltest/README.md
+		 - PR 260: Update test server generation/deployment scripts (libOQS 0.9.2)
+		 - PR 249: Renaming nginx/fulltest-provider -> nginx/fulltest & delete old fulltest dir.
+	- Open PRs:
+		 - PR 220: Update unbound DNS for openssl 3.x.x
+		 - PR 262: Add liboqs/oqsprovider tag/branch as build parameter
+	- Open Issues:
+		 - Issue 261: Add QUIC support
+		 - Issue 257: Introduce CI mechanism to use specific liboqs/oqs-provider versions
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+7. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+8. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+9. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 34: How to use x509 Certificate Signer on golang
+		 - Issue 25: Link liboqs statically
+
+
+12. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+13. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 57: Question: Worth while automating install?
+
+
+14. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+15. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-01-23 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-01-23 - OQS status meeting - minutes.md
@@ -1,0 +1,97 @@
+# 2024-01-23 - OQS status meeting - minutes
+
+*Attendees: Basil (IBM); Brian (AWS); Christian (MSR); Douglas, Pravek, Spencer (Waterloo); Mark (Cisco); Michael*
+
+### Next meeting: Tuesday January 30, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+<!--### Next meeting: Tuesday January 23 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+## Agenda
+
+1. Status updates
+2. liboqs 0.10.0 release planning
+3. Linux Foundation update
+
+## 1. Status updates
+
+### liboqs
+
+PR #1560 and #1677 are ready for review.
+
+PR #1676 will have discussion on the PR.
+
+ML-KEM and ML-DSA updates: There's a draft PR but still a few open points to do. Basil hopes to come back to it in a couple of weeks.
+
+AppVeyor is failing on liboqs.  It seems to be an OpenSSL linking failure.  Spencer to investigate.  But this raises some bigger questions:
+
+- Why aren't these included in the CI checks in GitHub?
+- Do we even need these?  If we can switch to covering all our Windows CI needs via GitHub Actions, that would simplify things
+- Spencer to investigate
+- Also need to update the dashboard
+
+### OpenSSL 3 Provider
+
+No updates.
+
+### BoringSSL
+
+Should we mark this is as obsolete or looking for help?  Discussion follows.  Consensus: clearly mark as "looking for help, not actively maintained".  Also update OQS www accordingly.  Michael can do PRs about this.
+
+### OpenSSH and libssh
+
+Should we mark this is as obsolete or looking for help?  Discussion follows.  Consensus: clearly mark as "looking for help, not actively maintained".  Also update OQS www accordingly.  Michael can do PRs about this.
+
+### OQS-Demos
+
+PR #262 ready for review.  Doesn't do tagging of Docker in CI so that will have to be manually done.
+
+### Profiling
+
+No updates.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+Vlad has a fix for issue #25.  Will release a version matching liboqs 0.9.2 later this week.  Regarding the X.509 issue #34, is this in scope of liboqs-go?  No, seems to be about higher level APIs in Go which are not part of the liboqs language wrapper.  Vlad to respond that it's out of scope then close.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+Vlad has a fix coming for issue #57 which will install liboqs if it's not found.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+Michael suggests downplaying unsupported sub-projects.  Douglas suggests highlighting OQS Provider but Michael doesn't think so.
+
+## 2. liboqs 0.10.0 release planning
+
+What should be included?
+
+- ML-KEM and ML-DSA are the most important
+- Falcon and stateful hash-based signatures are nice-to-have, if they are ready at that time
+
+## 3. Linux Foundation update
+
+OQS has completed its move into the LF.  The Post-Quantum Cryptography Alliance will launch on February 6.
+
+What needs to be done to prepare for launch?
+
+- Look at old issues at clean up (Spencer will start)
+- An FAQ
+- Checking over READMEs
+- Checking over website
+- Update dashboard and cleaning up failed builds

--- a/oqs-status-meetings/2024-01-30 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-01-30 - OQS status meeting - agenda.md
@@ -1,0 +1,279 @@
+# 2024-01-30 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday January 30 at 12:30 PM </span> US Eastern Time / 6:30 PM Central European / 9:30 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+2. Preparing for LF launch
+3. FIPS certification and talking to OpenSSL
+
+## OQS subprojects
+
+1. liboqs
+2. OQS-OpenSSL 3 provider
+3. OQS-BoringSSL
+4. OQS-OpenSSH
+5. OQS-libssh
+6. oqs-demos
+7. profiling
+8. ci-containers
+9. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+10. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1675: Add a document describing our subproject governance
+	- Open PRs:
+		 - PR 1560: Test against all 100 KAT values
+		 - PR 1603: Make common algorithms implementation pluggable
+		 - PR 1626: Add ML-DSA-ipd and ML-KEM-ipd & NIST supplied test vectors
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1653: find\_package(Threads) regardless of BUILD\_ONLY\_LIB
+		 - PR 1654: Run oqs-provider release tests in CI on release candidate branches
+		 - PR 1671: Call set\_available\_cpu\_extensions using pthread\_once
+		 - PR 1677: Update McEliece suppression files for generic config
+		 - PR 1679: Update BIKE documentation to exclude x86
+		 - PR 1680: Set the correct compile flag for the memory sanitizer build
+	- Open Issues:
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1676: Disable Stateful Signatures in the build by default
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1666: Update constant-time suppression files for Sphincs+ and McEliece generic configuration
+		 - Issue 1647: (Automated) downstream release testing
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1630: Improve CI for macOS on Apple Silicon
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1608: Support multiple Falcon signature formats
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1599: Make low-level crypto algorithms implementation switchable
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1564: Update README and other documentation to better describe algorithm status
+		 - Issue 1561: Falcon-1024 KATs differ from upstream
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1539: Update OpenSSL integration
+		 - Issue 1521: Update Kyber and Dilithium to FIPS versions
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1443: OQS\_ENABLE\_KEM\_BIKE forced to OFF for ARCH\_X86
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1418: Expand test coverage to all 100 NIST KAT values
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+2. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 342: bring GOVERNANCE in line with liboqs [skip ci]
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 317: Implementation of Composite Sig
+	- Open Issues:
+		 - Issue 343: No OpenSSL randomness retrieved. DRGB available?
+		 - Issue 339: .deb inside of oqsprovider-linux-x64.zip 0.5.3 does not work & prevents OpenSSL from loading
+		 - Issue 338: oqsprovider-linux-aarch64.zip 0.5.3, the .deb incorrectly identifies as AMD64
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 318: commit f205f116 broke tests
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+3. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+4. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 154: OQS SSH Key Signing for PKI fails with quantum-resistant algorithms
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+5. **OQS-libssh**
+
+
+	- Merges in the last 7 days:
+		 - PR 22: state project support status [skip ci]
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+6. **oqs-demos**
+
+
+	- Merges in the last 7 days:
+		 - PR 262: Add liboqs/oqsprovider tag/branch as build parameter
+		 - PR 263: convenience script to release specific OQS component versions [skip ci]
+	- Open PRs:
+		 - PR 220: Update unbound DNS for openssl 3.x.x
+	- Open Issues:
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+7. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+8. **ci-containers**
+
+
+	- Merges in the last 7 days:
+		 - PR 70: upgrade cmake through pip
+	- Open PRs: None
+	- Open Issues: None
+
+
+9. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 14: Error while trying to use liboqs-cpp
+
+
+10. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+11. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 34: How to use x509 Certificate Signer on golang
+		 - Issue 25: Link liboqs statically
+
+
+12. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+13. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 73: alpine:3.16 security upgrade
+	- Open Issues:
+		 - Issue 57: Question: Worth while automating install?
+
+
+14. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+15. **www.openquantumsafe.org** : No updates
+
+## 2. Preparing for LF launch
+
+What needs to be done to prepare for launch?
+
+- Look at old issues at clean up (Spencer will start)
+- An FAQ
+- Checking over READMEs
+- Checking over website
+- Update dashboard and cleaning up failed builds

--- a/oqs-status-meetings/2024-01-30 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-01-30 - OQS status meeting - minutes.md
@@ -1,0 +1,111 @@
+# 2024-01-30 - OQS status meeting - minutes
+
+*Attendees: Alex, Mark, Norm (Cisco); Douglas, Pravek, Spencer (Waterloo); Eric (AWS); Jason (SandboxAQ); Michael*
+
+<!--### Next meeting: Tuesday January 30, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+### Next meeting: Tuesday February 6 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+2. Preparing for LF launch
+3. FIPS certification and talking to OpenSSL
+
+## 1. Status updates
+
+### liboqs
+
+Stateful hash-based signatures: Norm working through how to handle function pointers in `OQS_SIG` data structure when keygen and sign are not enabled.  Then will replace some code with macro-based generation for consistency/easy of updates.
+
+Spencer has been doing some clean up of old issues and PRs.
+
+PRs ready for review: #1680, #1679, #1677, #1653, #1560.
+
+### OpenSSL 3 Provider
+
+No updates.
+
+### BoringSSL
+
+Following discussion last week about whether to declare this project inactive, received a reply from @pi-314159 that they are willing to update boringssl every 2-3 months.
+
+
+### OpenSSH and libssh
+
+Michael marked these two projects as presently inactive.
+
+### OQS-Demos
+
+Michael deployed the 0.9.2 release demos to Docker Hub.
+
+### Profiling
+
+No updates.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+No updates.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+No updates.
+
+**liboqs-rust.**
+Douglas received an expression of interest from Premachandra Mallappa at AMD about getting involved in Rust programming in OQS.  Douglas to  introduce Prem, Jason, Vlad in a group email, who have all expressed interesting in taking over support of liboqs-rust.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+Michael suggests downplaying unsupported sub-projects.  Douglas suggests highlighting OQS Provider but Michael doesn't think so.
+
+## 2. Preparing for LF Launch
+
+The Post-Quantum Cryptography Alliance will launch on February 6.
+
+What needs to be done to prepare for launch?
+
+- Checking over READMEs
+- Creating an FAQ?
+	- Michael create a USAGE.md file oqs-provider, might be useful in liboqs
+	- Douglas to start an FAQ for the website:
+		- What is PQ?
+		- What is the status of PQ standardization?
+		- What is OQS?
+		- What does quantum-safe mean?
+		- Do I need a quantum computer?
+		- Is OQS safe to use?
+		- How to get involved?
+		- How to use PQ with OpenSSL?
+		- How to use PQ in (my favourite programming language)?
+
+## 3. Discussions with outside groups: FIPS certification, OpenSSL
+
+### FIPS certification
+
+Douglas received an email from a FIPS certification lab, KeyPair.us, inquiring about our interest in seeking FIPS certification for OQS eventually.  Douglas thought it might be interesting to get them to tell us more about the process in general.
+
+Eric has observed that FIPS certification is on-going and time-consuming. It does open doors to new customers. PQ algorithms can't be certified yet since there are no final FIPS standards and no testing standards.
+
+Michael notes that it's very early -- too early to start any of this.  Michael notes that OpenSSL FIPS certification was done at no cost.  A discussion with a lab could involve asking them what's feasible for a project like ours.
+
+There is the suggestion that it would be better to hold off on this for a few months until things are clearer with NIST, as well as when the Kyber Code Package effort has developed more, since that group will also likely be interested.
+
+### OpenSSL
+
+Douglas notes that Nicola Tuveri will be visiting Waterloo in April to spend some time collaborating on research. He is also a member of the OpenSSL technical committee so this also seemed like a good opportunity to start discussing what interactions with OpenSSL may be possible. 
+
+Added after the call: start of a discussion with OpenSSL on GitHub: https://github.com/openssl/project/issues/431
+

--- a/oqs-status-meetings/2024-02-06 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-02-06 - OQS status meeting - agenda.md
@@ -1,0 +1,279 @@
+# 2024-02-06 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday February 06 at 10:00 AM </span> US Eastern Time / 4:00 PM Central European / 7:00 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+2. LF launch updates
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1653: find\_package(Threads) regardless of BUILD\_ONLY\_LIB
+		 - PR 1671: Call set\_available\_cpu\_extensions using pthread\_once
+		 - PR 1679: Update BIKE documentation to exclude x86
+		 - PR 1676: Disable Stateful Signatures in the build by default
+		 - PR 1560: Test against all 100 KAT values
+		 - PR 1680: Set the correct compile flag for the memory sanitizer build
+		 - PR 1682: Discontinue AppVeyor CI testing
+		 - PR 1654: Run oqs-provider release tests in CI on release candidate branches
+	- Open PRs:
+		 - PR 1603: Make common algorithms implementation pluggable
+		 - PR 1626: Add ML-DSA-ipd and ML-KEM-ipd & NIST supplied test vectors
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1677: Update McEliece suppression files for generic config
+		 - PR 1683: Update SPHINCS+ "clean" suppression files
+		 - PR 1684: Rename weekly runs and skip Falcon-1024 [skip ci]
+	- Open Issues:
+		 - Issue 1685: build with openssl, built with shlib\_variant
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1666: Update constant-time suppression files for Sphincs+ and McEliece generic configuration
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1630: Improve CI for macOS on Apple Silicon
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1608: Support multiple Falcon signature formats
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1599: Make low-level crypto algorithms implementation switchable
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1564: Update README and other documentation to better describe algorithm status
+		 - Issue 1561: Falcon-1024 KATs differ from upstream
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1539: Update OpenSSL integration
+		 - Issue 1521: Update Kyber and Dilithium to FIPS versions
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 347: correct wrong use of sizeof
+		 - PR 346: add more defensive error handling
+		 - PR 345: Automatically run release tests on liboqs release candidates
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 317: Implementation of Composite Sig
+		 - PR 344: first cut adding ML-*
+		 - PR 348: first cut adding ML-*
+	- Open Issues:
+		 - Issue 339: .deb inside of oqsprovider-linux-x64.zip 0.5.3 does not work & prevents OpenSSL from loading
+		 - Issue 338: oqsprovider-linux-aarch64.zip 0.5.3, the .deb incorrectly identifies as AMD64
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 318: commit f205f116 broke tests
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 155: Fix CI failure
+		 - Issue 154: OQS SSH Key Signing for PKI fails with quantum-resistant algorithms
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 220: Update unbound DNS for openssl 3.x.x
+	- Open Issues:
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 14: Error while trying to use liboqs-cpp
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 25: Link liboqs statically
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 73: alpine:3.16 security upgrade
+		 - PR 75: Remove support for NIST KAT RNG
+	- Open Issues:
+		 - Issue 74: Kat-Vector-Falcon
+		 - Issue 57: Question: Worth while automating install?
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-02-13 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-02-13 - OQS status meeting - agenda.md
@@ -1,0 +1,276 @@
+# 2024-02-13 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday February 13 at 12:30 PM </span> US Eastern Time / 6:30 PM Central European / 9:30 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1686: Fix link in GOVERNANCE.md
+		 - PR 1690: Update Sphincs+ Markdown documentation from YAML
+		 - PR 1688: properly document release support level [skip ci]
+		 - PR 1684: Rename weekly runs and skip Falcon-1024 [skip ci]
+		 - PR 1683: Update SPHINCS+ "clean" suppression files
+		 - PR 1677: Update McEliece suppression files for generic config
+		 - PR 1687: Na stateful macro
+		 - PR 1695: set(OQS\_USE\_PTHREADS OFF) on MinGW/Cygwin
+	- Open PRs:
+		 - PR 1603: Make common algorithms implementation pluggable
+		 - PR 1626: Add ML-DSA-ipd and ML-KEM-ipd & NIST supplied test vectors
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1694: Refactor OpenSSL Implementation of SHA3 SHAKE to use new Squeeze API
+		 - PR 1696: Fix cross compilation and test in CI
+	- Open Issues:
+		 - Issue 1692: Update GitHub Actions workflows for stateful signatures
+		 - Issue 1691: Align platforms supported with OpenSSL
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1630: Improve CI for macOS on Apple Silicon
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1608: Support multiple Falcon signature formats
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1599: Make low-level crypto algorithms implementation switchable
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1564: Update README and other documentation to better describe algorithm status
+		 - Issue 1561: Falcon-1024 KATs differ from upstream
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1539: Update OpenSSL integration
+		 - Issue 1521: Update Kyber and Dilithium to FIPS versions
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 350: Protecting from NULL parameters
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 317: Implementation of Composite Sig
+		 - PR 344: first cut adding ML-*
+		 - PR 348: first cut adding ML-*
+	- Open Issues:
+		 - Issue 339: .deb inside of oqsprovider-linux-x64.zip 0.5.3 does not work & prevents OpenSSL from loading
+		 - Issue 338: oqsprovider-linux-aarch64.zip 0.5.3, the .deb incorrectly identifies as AMD64
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 318: commit f205f116 broke tests
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 155: Fix CI failure
+		 - Issue 154: OQS SSH Key Signing for PKI fails with quantum-resistant algorithms
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 220: Update unbound DNS for openssl 3.x.x
+	- Open Issues:
+		 - Issue 265: Not able to get OQS-Chromium browser working - https://openquantumsafe.org/applications/tls.html#chromium
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 71: Install MinGW in Focal for cross-compilation
+	- Open Issues:
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 25: Link liboqs statically
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 73: alpine:3.16 security upgrade
+		 - PR 75: Remove support for NIST KAT RNG
+	- Open Issues:
+		 - Issue 74: Kat-Vector-Falcon
+		 - Issue 57: Question: Worth while automating install?
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-02-13 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-02-13 - OQS status meeting - minutes.md
@@ -1,0 +1,77 @@
+# 2024-02-13 - OQS status meeting - minutes
+
+<!--*Attendees: Alex, Mark, Norm (Cisco); Douglas, Pravek, Spencer (Waterloo); Eric (AWS); Jason (SandboxAQ); Michael*-->
+
+<!--### Next meeting: Tuesday January 30, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+### Next meeting: Tuesday February 20 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Top-level discussions
+1. Status updates
+
+## 1. Top-level discussions
+
+There are discussion posts in the top-level OQS GitHub organization discussions section on subproject status and other issues, please take a look.
+
+## 2. Status updates
+
+### liboqs
+
+ML-KEM and ML-DSA: Ready for review.
+
+Stateful hash-based signatures: ready for review.  Aim to merge next week.
+
+Michael uncertain if trigger from liboqs to oqs-provider has been triggered. Spencer says the second last commit seems to have done this.
+
+### OpenSSL 3 Provider
+
+Code review from Radically Open Security is mostly done, so code freeze can be lifted.
+
+ML-KEM and ML-DSA: Ready for review.  Michael to remove draft status once it's confirmed that CI triggers are okay.
+
+### BoringSSL
+
+No updates.
+
+### OpenSSH and libssh
+
+No updates.
+
+### OQS-Demos
+
+No updates.
+
+### Profiling
+
+Spencer wants to revisit M1 profiling and consider moving to GitHub Actions.  Douglas cautions that benchmarking via GitHub Actions may not be reliable.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+No updates.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+No updates.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.
+

--- a/oqs-status-meetings/2024-02-20 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-02-20 - OQS status meeting - agenda.md
@@ -1,0 +1,272 @@
+# 2024-02-20 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday February 20 at 10:00 AM </span> US Eastern Time / 4:00 PM Central European / 7:00 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 2: OQS sub projects: Which ones to drop for good
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1697: Change XMSS License from `(Apache 2.0 AND MIT)` to `(Apache 2.0 OR MIT) AND CC0-1.0`
+		 - PR 1696: Fix cross compilation and test in CI
+		 - PR 1692: Update GitHub Actions workflows for stateful signatures
+		 - PR 1701: update brew install instructions to use openssl@3 instead of openssl@1.1.1 [skip ci]
+		 - PR 1626: Add ML-DSA-ipd and ML-KEM-ipd & NIST supplied test vectors
+	- Open PRs:
+		 - PR 1603: Make common algorithms implementation pluggable
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1694: Refactor OpenSSL Implementation of SHA3 SHAKE to use new Squeeze API
+		 - PR 1699: Update liboqs readme to point to oqs-provider instead of deprecated openssl1.1.1 fork [skip-ci]
+		 - PR 1700: change from ninja and custom cmake target `run\_test` to using cmake & ctest.
+	- Open Issues:
+		 - Issue 1691: Align platforms supported with OpenSSL
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1630: Improve CI for macOS on Apple Silicon
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1608: Support multiple Falcon signature formats
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1599: Make low-level crypto algorithms implementation switchable
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1564: Update README and other documentation to better describe algorithm status
+		 - Issue 1561: Falcon-1024 KATs differ from upstream
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1539: Update OpenSSL integration
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 317: Implementation of Composite Sig
+		 - PR 344: first cut adding ML-*
+		 - PR 348: first cut adding ML-*
+	- Open Issues:
+		 - Issue 339: .deb inside of oqsprovider-linux-x64.zip 0.5.3 does not work & prevents OpenSSL from loading
+		 - Issue 338: oqsprovider-linux-aarch64.zip 0.5.3, the .deb incorrectly identifies as AMD64
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 318: commit f205f116 broke tests
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 155: Fix CI failure
+		 - Issue 154: OQS SSH Key Signing for PKI fails with quantum-resistant algorithms
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 220: Update unbound DNS for openssl 3.x.x
+	- Open Issues:
+		 - Issue 266: oqs-epiphany not working 
+		 - Issue 265: Not able to get OQS-Chromium browser working - https://openquantumsafe.org/applications/tls.html#chromium
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days:
+		 - PR 71: Install MinGW in Focal for cross-compilation
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 25: Link liboqs statically
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 73: alpine:3.16 security upgrade
+		 - PR 75: Remove support for NIST KAT RNG
+	- Open Issues:
+		 - Issue 74: Kat-Vector-Falcon
+		 - Issue 57: Question: Worth while automating install?
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-02-20 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-02-20 - OQS status meeting - minutes.md
@@ -1,0 +1,77 @@
+# 2024-02-20 - OQS status meeting - minutes
+
+*Attendees: Basil (IBM); Brian (AWS); Christian (MSR); Douglas, Pravek, Spencer (Waterloo); Jason (SandboxAQ); Mark (Cisco); Sara (Synopsys)*
+
+### Next meeting: Tuesday February 27, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+<!--### Next meeting: Tuesday February 20 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+## Agenda
+
+1. Status updates
+
+## 1. Status updates
+
+### liboqs
+
+ML-KEM and ML-DSA: Have landed on main.
+
+0.10.0 release: What else do we want to include a 0.10.0 release?
+
+- Stateful hash-based signatures
+- Falcon: Spencer notes that this is blocked on PQClean
+
+Jason looking at home to remove Ninja and rely solely on CMake for builds. Douglas asks if we would lose Visual Studio project generation?  Jason to investigate and discuss with Michael. Jason asks about switching tests from Pytest to CMake tests.  Douglas suggests holding off on this for now, and focusing just on the Ninja -> CMake build switch.  Jason to add discussion to an issue on this.
+
+Basil looking at adding the Mayo signature scheme from the on-ramp with C and AVX2 implementation.  Basil also thinks there's interest in adding SQIsign, although that is a larger code base and has some external dependencies.
+
+### OpenSSL 3 Provider
+
+ML-KEM and ML-DSA: Need to resolve how OIDs are going to work, then will be ready to merge.
+
+Pravek to ping Entrust about reviving #312 once ML-KEM and ML-DSA land.
+
+### BoringSSL
+
+No updates.
+
+### OpenSSH and libssh
+
+Brian asks is there a plan to update SSH to ML-KEM. Douglas says no plan at this point.  Brian says that AWS will eventually be updating their SSH tools to support ML-KEM and would like to be able to interop with one of the OQS SSH implementations; will raise the issue again once they get to the work on their side.
+
+### OQS-Demos
+
+No updates.
+
+### Profiling
+
+No updates.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+No updates.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+No updates.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.
+

--- a/oqs-status-meetings/2024-02-27 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-02-27 - OQS status meeting - agenda.md
@@ -1,0 +1,277 @@
+# 2024-02-27 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday February 27 at 12:30 PM </span> US Eastern Time / 6:30 PM Central European / 9:30 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+2. 0.10.0 planning
+3. PQ Code Package discussion
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 2: OQS sub projects: Which ones to drop for good
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1702: Small fixes after adding ML-*
+	- Open PRs:
+		 - PR 1603: Make common algorithms implementation pluggable
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1694: Refactor OpenSSL Implementation of SHA3 SHAKE to use new Squeeze API
+		 - PR 1699: Update liboqs readme to point to oqs-provider instead of deprecated openssl1.1.1 fork [skip-ci]
+		 - PR 1700: change from ninja and custom cmake target `run\_test` to using cmake & ctest.
+		 - PR 1707: Add MAYO signature scheme from NIST onramp
+	- Open Issues:
+		 - Issue 1706: Add OpenSSF scorecard
+		 - Issue 1705: Handle out-of-memory errors gracefully
+		 - Issue 1704: Add tests for alias behaving identically to at least one baseline alg.
+		 - Issue 1703: `filter\_args` not correctly functioning
+		 - Issue 1691: Align platforms supported with OpenSSL
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1630: Improve CI for macOS on Apple Silicon
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1608: Support multiple Falcon signature formats
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1599: Make low-level crypto algorithms implementation switchable
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1564: Update README and other documentation to better describe algorithm status
+		 - Issue 1561: Falcon-1024 KATs differ from upstream
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1539: Update OpenSSL integration
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 348: first cut adding ML-*
+		 - PR 352: guard external testing against algorithm absence
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 317: Implementation of Composite Sig
+	- Open Issues:
+		 - Issue 354: Adapt oqsprovider to liboqs version
+		 - Issue 353: Make CI using downstream integrations optional
+		 - Issue 351: Document & curate (O)IDs
+		 - Issue 339: .deb inside of oqsprovider-linux-x64.zip 0.5.3 does not work & prevents OpenSSL from loading
+		 - Issue 338: oqsprovider-linux-aarch64.zip 0.5.3, the .deb incorrectly identifies as AMD64
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 155: Fix CI failure
+		 - Issue 154: OQS SSH Key Signing for PKI fails with quantum-resistant algorithms
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 220: Update unbound DNS for openssl 3.x.x
+	- Open Issues:
+		 - Issue 266: oqs-epiphany not working 
+		 - Issue 265: Not able to get OQS-Chromium browser working - https://openquantumsafe.org/applications/tls.html#chromium
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 15: Seeing compilation failure here.
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 25: Link liboqs statically
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 73: alpine:3.16 security upgrade
+		 - PR 75: Remove support for NIST KAT RNG
+	- Open Issues:
+		 - Issue 74: Kat-Vector-Falcon
+		 - Issue 57: Question: Worth while automating install?
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-02-27 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-02-27 - OQS status meeting - minutes.md
@@ -1,0 +1,82 @@
+# 2024-02-27 - OQS status meeting - minutes
+
+*Attendees: Alex (Cisco); Eric (AWS); Douglas, Pravek, Spencer (Waterloo); Jason (SandboxAQ); Michael; Sara (Synopsys)*
+
+<!--### Next meeting: Tuesday February 27, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+### Next meeting: Tuesday March 5 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. TSC meeting
+1. Status updates
+
+### 1. TSC meeting
+
+Douglas needs to schedule a OQS TSC meeting.
+
+## 2. Status updates
+
+### liboqs
+
+Stateful hash-based signatures: review continues.
+
+Falcon: Ready for review in PQClean and then can merge into OQS.
+
+0.10.0:
+
+- Falcon should be straightforward and a quick review.
+- Stateful hash-based signatures could be further out since it's such a big PR.
+- Michael would prefer an earlier 0.10.0 release to land ML-KEM-ipd and ML-DSA-ipd soon, and then can hold SHBS for 0.11.0.
+- We will target a release candidate by next week.
+
+### OpenSSL 3 Provider
+
+KEM OIDs: Pravek to investigate what the IETF Interop is using.
+
+### BoringSSL
+
+No updates.
+
+### OpenSSH and libssh
+
+No updates.
+
+### OQS-Demos
+
+Will need to be updated with ML-KEM and ML-DSA.
+
+### Profiling
+
+Will need to be updated with ML-KEM and ML-DSA.
+
+Noting that profiling is in a deteriorated state.  Spencer would like to redo profiling.  Should have some discussions about our intended use case for profiling.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+No updates.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+No updates.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.
+

--- a/oqs-status-meetings/2024-03-05 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-03-05 - OQS status meeting - agenda.md
@@ -1,0 +1,291 @@
+# 2024-03-05 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday March 05 at 10:00 AM </span> US Eastern Time / 4:00 PM Central European / 7:00 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+2. liboqs release 0.10.0-rc1 planning
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 2: OQS sub projects: Which ones to drop for good
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1712: Add return status for XMSS lock/unlock functions.
+		 - PR 1714: Fix for the Zephyr CI tests
+		 - PR 1709: Move MacOS CI tests to GitHub Actions; add M1 CI tests
+		 - PR 1699: Update liboqs readme to point to oqs-provider instead of deprecated openssl1.1.1 fork [skip ci]
+		 - PR 1715: fix documentation generation
+		 - PR 1713: remove references to unsupported openssh [skip ci]
+	- Open PRs:
+		 - PR 1603: Make common algorithms implementation pluggable
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1694: Refactor OpenSSL Implementation of SHA3 SHAKE to use new Squeeze API
+		 - PR 1700: change from ninja and custom cmake target `run\_test` to using cmake & ctest.
+		 - PR 1707: Add MAYO signature scheme from NIST onramp
+		 - PR 1708: Create scorecard.yml (OpenSSF)
+		 - PR 1710: Support Falcon PADDED format
+		 - PR 1716: Fix for alg\_support.cmake
+		 - PR 1717: Proposed build wrapper script for static libs macOS / iOS / Android platforms
+	- Open Issues:
+		 - Issue 1706: Add OpenSSF scorecard
+		 - Issue 1705: Handle out-of-memory errors gracefully
+		 - Issue 1704: Add tests for alias behaving identically to at least one baseline alg.
+		 - Issue 1703: `filter\_args` not correctly functioning
+		 - Issue 1691: Align platforms supported with OpenSSL
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1608: Support multiple Falcon signature formats
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1599: Make low-level crypto algorithms implementation switchable
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1564: Update README and other documentation to better describe algorithm status
+		 - Issue 1561: Falcon-1024 KATs differ from upstream
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1539: Update OpenSSL integration
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 357: Add extra debug information in case of TLS handshake failure.
+		 - PR 356: Adapt Kyber OIDs and avoid testing using downlevel brew releases
+		 - PR 361: p384\_mlkem1024 hybrid added
+		 - PR 364: length and null checks in en/decaps
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 317: Implementation of Composite Sig
+		 - PR 362: Add code points for PADDED variant of Falcon [skip ci]
+		 - PR 363: Updates for clean builds across iOS / macOS / Android (all platforms)
+	- Open Issues:
+		 - Issue 360: Getting message "too weak" when launching openssl server
+		 - Issue 359: Listing signatures or KEMs according to USAGE.md does not work as intended
+		 - Issue 358: oqs\_tlssig fails against OpenSSL 3.2.1
+		 - Issue 354: Adapt oqsprovider to liboqs version
+		 - Issue 353: Make CI using downstream integrations optional
+		 - Issue 351: Document & curate (O)IDs
+		 - Issue 339: .deb inside of oqsprovider-linux-x64.zip 0.5.3 does not work & prevents OpenSSL from loading
+		 - Issue 338: oqsprovider-linux-aarch64.zip 0.5.3, the .deb incorrectly identifies as AMD64
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days:
+		 - PR 109: Update to upstream df3b58e
+		 - PR 110: Add X25519 hybrid key exchange algorithms support
+		 - PR 112: Add Module-Lattice-Based Algorithms (ML-*) Support
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days:
+		 - PR 157: Enable shared build & fix build script
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 220: Update unbound DNS for openssl 3.x.x
+	- Open Issues:
+		 - Issue 266: oqs-epiphany not working 
+		 - Issue 265: Not able to get OQS-Chromium browser working - https://openquantumsafe.org/applications/tls.html#chromium
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 25: Link liboqs statically
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 73: alpine:3.16 security upgrade
+		 - PR 75: Remove support for NIST KAT RNG
+	- Open Issues:
+		 - Issue 74: Kat-Vector-Falcon
+		 - Issue 57: Question: Worth while automating install?
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-03-05 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-03-05 - OQS status meeting - minutes.md
@@ -1,0 +1,119 @@
+# 2024-03-05 - OQS status meeting - minutes
+
+### Next meeting: Tuesday March 12, 2024 at 12:30pm US Eastern time / <span style="color: red;">5:30pm Central European (note change to Daylight Saving Time in North America)</span> / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+<!--### Next meeting: Tuesday February 27, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+<!--### Next meeting: Tuesday March 5 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+## Attendees
+
+- Alex B, Basil, Max, Nigel (IBM)
+- Brian (AWS)
+- Christian (MSR)
+- Douglas, Spencer (Waterloo)
+- Jason, Thomas (SandboxAQ)
+- Mark, Norm (Cisco)
+- Michael
+- Prem (AMD)
+- Ry (Linux Foundation)
+- Sara (Synopsys)
+
+## Agenda
+
+1. Welcome
+1. Status updates
+1. PQ Code Package virtual hack day
+
+## 1. Welcome
+
+Welcome to the new faces joining the call!
+
+Ry reminds people that if they would like to join the PQCA Discord, it's at https://discord.gg/xyVnwzfg5R.
+
+## 2. Status updates
+
+### liboqs
+
+Falcon: A few small things were left to deal with - naming conventions and a superfluous license
+	- License issue: dealt with
+	- Naming conventions: Spencer has a draft PR to fix this in PQClean; need reviews. Then can finalize Falcon updates in liboqs.
+
+Stateful hash-based signatures:
+
+- Spencer continuing to review.
+- Norm will respond to questions from Spencer about files from upstream.
+- Norm can help with XMSS feedback when it comes in.
+- Christian attended NCCoE meeting on SHBS. NIST looking at comments from implementers about restrictions on state management and export.
+
+alg_support.cmake: Basil and Michael have agreed on a path forward. Basil will update the PR.
+
+OpenSSF scorecard: still some issues to address.
+
+#### 0.10.0 release planning
+
+Agreed to save SHBS for 0.11.0.
+
+Michael things all other issues in the 0.10.0 milestone should be easily addressable and will work with Spencer to finalize them.  Spencer noticed some constant-time failure on SPHINCS+; will create issue.
+
+Spencer and Michael will prepare the release notes and tag -rc1.
+
+### OpenSSL 3 Provider
+
+OIDs:
+
+- Michael would like to see someone take leadership on list of OIDs -- too many places to check.
+- Basil says IBM has OIDs for ML-DSA-ipd and the Bouncycastle has OIDs for ML-KEM-ipd.
+- This discussion can be directed towards issue #351.
+
+Thanks to Spencer for preparing the PR for Falcon-padded.  
+
+Michael wants to know about the prospect of including composite sigs (#317) in the next release. Will continue discussion on pull request.
+
+### BoringSSL
+
+Some recent updates. Michael working with contributor pi-314159 to continue. Anticipate that BoringSSL will (still) not have as full support as oqs-provider, but will have some algorithm updates.
+
+### OpenSSH and libssh
+
+Brian will check with the AWS team to see if they have bandwidth to update OpenSSH. They will eventually want to interop with it when they get further along with ML-KEM internally
+
+### OQS-Demos
+
+Will need to be updated with ML-KEM and ML-DSA.  Volunteers welcome.
+
+### Profiling
+
+No updates.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+No updates.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+No updates.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.
+
+## 3. PQ Code Package virtual hack day
+
+The PQ Code Package virtual hack day will take place on Tuesday March 12.  For more information, see https://hackathon.pqcodepackage.org/ or contact Nigel Jones (jonesn@Uk.ibm.com).

--- a/oqs-status-meetings/2024-03-12 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-03-12 - OQS status meeting - agenda.md
@@ -1,0 +1,288 @@
+# 2024-03-12 - OQS status meeting - agenda
+
+Tuesday March 12 at 12:30 PM US Eastern Time / <span style="color: red;">5:30 PM Central European (note Daylight Saving Time change in North America but not Europe means meeting start time in Europe is different this week)</span> / 9:30 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+2. Feedback on liboqs 0.10.0-rc1
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days:
+		 - PR 3: add zoom link
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 2: OQS sub projects: Which ones to drop for good
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1710: Support Falcon PADDED format
+		 - PR 1716: Fix for alg\_support.cmake
+		 - PR 1721: improve algorithm documentation [skip ci]
+		 - PR 1720: Fix SPHINCS+ naming in CT tests [skip ci]
+		 - PR 1727: Add return check for lock/unlock function
+		 - PR 1722: Reformat LMS / XMSS KAT files
+	- Open PRs:
+		 - PR 1603: Add option to dynamically load libcrypto.so.*
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1694: Refactor OpenSSL Implementation of SHA3 SHAKE to use new Squeeze API
+		 - PR 1700: change from ninja and custom cmake target `run\_test` to using cmake & ctest.
+		 - PR 1707: Add MAYO signature scheme from NIST onramp
+		 - PR 1708: Create scorecard.yml (OpenSSF)
+		 - PR 1717: Proposed build wrapper script for static libs macOS / iOS / Android platforms
+		 - PR 1725: Always build "internal" library as static
+	- Open Issues:
+		 - Issue 1724: Reduce number of `malloc/free` call in `XMSS/external`
+		 - Issue 1723: 0.10.0-rc1: kat-kem: liboqs-internal.so => not found
+		 - Issue 1719: Improve algorithm versioning
+		 - Issue 1706: Add OpenSSF scorecard
+		 - Issue 1705: Handle out-of-memory errors gracefully
+		 - Issue 1691: Align platforms supported with OpenSSL
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1599: Make low-level crypto algorithms implementation switchable
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1539: Update OpenSSL integration
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 366: documentation update [skip ci]
+		 - PR 368: Set Kyber OIDs
+		 - PR 362: Add code points for PADDED variant of Falcon [skip ci]
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 317: Implementation of Composite Sig
+		 - PR 363: Updates for clean builds across iOS / macOS / Android (all platforms)
+		 - PR 367: improve static build testing
+		 - PR 369: Do not duplicate call to `getenv`.
+	- Open Issues:
+		 - Issue 370: tlstest\_helpers.c can‘t recognize pem files signed by the post-quantum algorithm
+		 - Issue 360: Getting message "too weak" when launching openssl server
+		 - Issue 359: Listing signatures or KEMs according to USAGE.md does not work as intended
+		 - Issue 358: oqs\_tlssig fails against OpenSSL 3.2.1
+		 - Issue 354: Adapt oqsprovider to liboqs version
+		 - Issue 353: Make CI using downstream integrations optional
+		 - Issue 351: Document & curate (O)IDs
+		 - Issue 339: .deb inside of oqsprovider-linux-x64.zip 0.5.3 does not work & prevents OpenSSL from loading
+		 - Issue 338: oqsprovider-linux-aarch64.zip 0.5.3, the .deb incorrectly identifies as AMD64
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days:
+		 - PR 113: Allow libpki to verify quantum safe signatures
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 220: Update unbound DNS for openssl 3.x.x
+		 - PR 268: 2024 March Chromium update [skip ci]
+	- Open Issues:
+		 - Issue 266: oqs-epiphany not working 
+		 - Issue 265: Not able to get OQS-Chromium browser working - https://openquantumsafe.org/applications/tls.html#chromium
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 25: Link liboqs statically
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 73: alpine:3.16 security upgrade
+		 - PR 75: Remove support for NIST KAT RNG
+	- Open Issues:
+		 - Issue 74: Kat-Vector-Falcon
+		 - Issue 57: Question: Worth while automating install?
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-03-12 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-03-12 - OQS status meeting - minutes.md
@@ -1,0 +1,95 @@
+# 2024-03-12 - OQS status meeting - minutes
+
+<!--### Next meeting: Tuesday March 12, 2024 at 12:30pm US Eastern time / <span style="color: red;">5:30pm Central European (note change to Daylight Saving Time in North America)</span> / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+-->
+<!--### Next meeting: Tuesday February 27, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+### Next meeting: Tuesday March 19 at 10:00am US Eastern time / <span style="color: red;">3:00pm Central European (note change to Daylight Saving Time in North America)</span> / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Attendees
+
+- Alex B (IBM)
+- Alex H, Norm (Cisco)
+- Christian (MSR)
+- Douglas, Pravek (Waterloo)
+- Jason (SandboxAQ)
+
+## Agenda
+
+1. Status updates
+1. Feedback on liboqs 0.10.0-rc1
+2. Other business
+
+## 1. Status updates
+
+### OQS TSC
+
+Douglas gave a recap of the OQS Technical Steering Committee meeting from Monday March 11.  
+
+### liboqs
+
+PR #1723: This can be merged and then Douglas will make a new 0.10.0 release candidates.
+
+PR #1700: Jason will resume work on this soon, for inclusion in the next release after 0.10.0.
+
+PR #1729: Pravek has created a draft PR for the libjade-based implementation of Kyber.
+
+### OpenSSL 3 Provider
+
+No updates.
+
+### BoringSSL
+
+No updates.
+
+### OpenSSH and libssh
+
+No updates.
+
+### OQS-Demos
+
+Will need to be updated with ML-KEM and ML-DSA.  Volunteers welcome.
+
+### Profiling
+
+No updates.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+No updates.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+No updates.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.
+
+## 2. Feedback on liboqs 0.10.0-rc1
+
+No additional feedback received.  Douglas will tag -rc2 after #1723 lands.
+
+## 3. Other business
+
+Douglas will not be at the next two weekly meetings; Basil will chair them.
+
+Douglas mentions that in April Nicola Tuveri, a PhD student from Finland who wants to do research on PQ implementations and who is also a member of the OpenSSL technical committee, will be visiting Waterloo for a few weeks.  Hope to have some discussions about how OQS and OpenSSL might be able to work together, and can meet with others who are interested.  Norm would like to be involved.
+
+Alex B asks if the OQS status call will move over to the Linux Foundation Zoom platform.  On the one hand, there are some nice benefits, like it showing up in your meeting dashboard and recordings and transcripts being stored automatically.  On the other hand, it does require people to be signed into a Zoom account, a feature LF has turned on to help manage abuse across calls on LF projects.  What would people prefer?

--- a/oqs-status-meetings/2024-04-02 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-04-02 - OQS status meeting - agenda.md
@@ -1,0 +1,286 @@
+# 2024-04-02 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday April 02 at 10:00 AM </span> US Eastern Time / 4:00 PM Central European / 7:00 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 9: Schedule next TSC meeting
+		 - Issue 8: FYI: open-quantum-safe/rust team has crates.io push access
+		 - Issue 7: Meeting minutes?
+		 - Issue 5: CI in OQS: guidelines for responsible use
+		 - Issue 2: OQS sub projects: Which ones to drop for good
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1724: Reduce number of `malloc/free` call in `XMSS/external`
+	- Open PRs:
+		 - PR 1603: Add option to dynamically load libcrypto.so.*
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1694: Refactor OpenSSL Implementation of SHA3 SHAKE to use new Squeeze API
+		 - PR 1700: change from ninja and custom cmake target `run\_test` to using cmake & ctest.
+		 - PR 1707: Add MAYO signature scheme from NIST onramp
+		 - PR 1708: Create scorecard.yml (OpenSSF)
+		 - PR 1717: Proposed build wrapper script for static libs macOS / iOS / Android platforms
+		 - PR 1729: Integrate Kyber from libjade
+		 - PR 1735: Document Fix
+		 - PR 1739: [NFCI] Move Keccak rhotates tables to rodata
+	- Open Issues:
+		 - Issue 1740: Add more test vectors for ML-KEM
+		 - Issue 1719: Improve algorithm versioning
+		 - Issue 1706: Add OpenSSF scorecard
+		 - Issue 1705: Handle out-of-memory errors gracefully
+		 - Issue 1691: Align platforms supported with OpenSSL
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1599: Make low-level crypto algorithms implementation switchable
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1539: Update OpenSSL integration
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 363: Updates for clean builds across iOS / macOS / Android (all platforms)
+		 - PR 367: improve static build testing
+	- Open Issues:
+		 - Issue 381: Composite sigs for mldsa trigger test failures
+		 - Issue 375: Refactor code
+		 - Issue 372: How to separate the post-quantum algorithmic key and the classical key in the generated pkey
+		 - Issue 360: Getting message "too weak" when launching openssl server
+		 - Issue 358: oqs\_tlssig fails against OpenSSL 3.2.1
+		 - Issue 354: Adapt oqsprovider to liboqs version
+		 - Issue 353: Make CI using downstream integrations optional
+		 - Issue 351: Document & curate (O)IDs
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 271: Update test server with liboqs 0.10.0 release
+		 - Issue 270: Dont get Server Temp Key in openssl s\_client when testing
+		 - Issue 266: oqs-epiphany not working 
+		 - Issue 265: Not able to get OQS-Chromium browser working - https://openquantumsafe.org/applications/tls.html#chromium
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days:
+		 - PR 18: Version 0.10.0
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days:
+		 - PR 36: Fix build with Go v1.22.1, liboqs v0.10.0
+		 - PR 37: Version 0.10.0
+	- Open PRs: None
+	- Open Issues: None
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days:
+		 - PR 73: alpine:3.16 security upgrade
+		 - PR 77: fix searching issue
+		 - PR 75: Remove support for NIST KAT RNG
+		 - PR 81: Win auto install
+		 - PR 80: V0.10.0
+	- Open PRs:
+		 - PR 82: Various changes upon functionality and security checks
+	- Open Issues:
+		 - Issue 78: Importing OpenSSL keys and certificates
+		 - Issue 74: Kat-Vector-Falcon
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 256: chore(ci): bump the actions group with 1 update
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-04-02 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-04-02 - OQS status meeting - minutes.md
@@ -1,0 +1,84 @@
+# 2024-04-02 - OQS status meeting - minutes
+
+### Next meeting: Tuesday April 9, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+<!--### Next meeting: Tuesday February 27, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+## Attendees
+
+- Basil (IBM)
+- Douglas, Pravek, Spencer (Waterloo)
+- Hart (Linux Foundation)
+- Mark (Cisco)
+- Sara (Synopsys)
+- Thomas (SandboxAQ)
+- Vlad (softwareQ)
+
+## Agenda
+
+1. Status updates
+
+## 1. Status updates
+
+### OQS TSC
+
+Vlad interested in joining the TSC.
+
+Douglas to schedule a TSC meeting for later next week.
+
+[#5 CI in OQS: guidelines for responsible use](https://github.com/open-quantum-safe/tsc/issues/5): Basil and Thomas will start a Markdown file on best practices.
+
+### liboqs
+
+Stateful hash-based signatures: Spencer picking up his review of the SHBS PR again.
+
+Pravek still working on adding libjade as an upstream to liboqs. Rebasing to address some merge conflicts; Spencer can help.
+
+### OpenSSL 3 Provider
+
+[Composite sigs for mldsa trigger test failures #381](https://github.com/open-quantum-safe/oqs-provider/issues/381) is blocking a release of oqs-provider and test server update.
+
+### BoringSSL
+
+No updates.
+
+### OpenSSH and libssh
+
+No updates.
+
+### OQS-Demos
+
+[Composite sigs for mldsa trigger test failures #381](https://github.com/open-quantum-safe/oqs-provider/issues/381) is blocking a release of oqs-provider and test server update.
+
+### Profiling
+
+No updates.
+
+### Language wrappers
+
+**liboqs-cpp.**
+Vlad did a 0.10.0 release.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+Vlad did a 0.10.0 release.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+Vlad did a 0.10.0 release. Also landed support for auto-install of liboqs if not present when installing liboqs-python.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.
+

--- a/oqs-status-meetings/2024-04-09 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-04-09 - OQS status meeting - agenda.md
@@ -1,0 +1,291 @@
+# 2024-04-09 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday April 09 at 12:30 PM </span> US Eastern Time / 6:30 PM Central European / 9:30 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 13: Does OQS-BoringSSL respository require a license exemption?
+		 - Issue 12: Create a voting procedure for the OQS TSC
+		 - Issue 11: Confirm mailing list openness and retention
+		 - Issue 10: Update config.yaml
+		 - Issue 9: Schedule next TSC meeting
+		 - Issue 8: FYI: open-quantum-safe/rust team has crates.io push access
+		 - Issue 7: Meeting minutes?
+		 - Issue 5: CI in OQS: guidelines for responsible use
+		 - Issue 2: OQS sub projects: Which ones to drop for good
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1739: [NFCI] Move Keccak rhotates tables to rodata
+		 - PR 1743: switching to dev mode again
+		 - PR 1735: Document Fix
+		 - PR 1603: Add option to dynamically load libcrypto.so.*
+		 - PR 1694: Refactor OpenSSL Implementation of SHA3 SHAKE to use new Squeeze API
+		 - PR 1751: Allow windows linking of test programs
+	- Open PRs:
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1700: change from ninja and custom cmake target `run\_test` to using cmake & ctest.
+		 - PR 1707: Add MAYO signature scheme from NIST onramp
+		 - PR 1708: Create scorecard.yml (OpenSSF)
+		 - PR 1717: Proposed build wrapper script for static libs macOS / iOS / Android platforms
+		 - PR 1745: Integrate Kyber from libjade 
+		 - PR 1747: remove "maximum" words for most length fields
+	- Open Issues:
+		 - Issue 1750: Return value from OQS\_randombytes
+		 - Issue 1744: The "(maximum) length" words in `OQS\_SIG` and `OQS\_KEM` are misleading
+		 - Issue 1740: Add more test vectors for ML-KEM
+		 - Issue 1719: Improve algorithm versioning
+		 - Issue 1706: Add OpenSSF scorecard
+		 - Issue 1705: Handle out-of-memory errors gracefully
+		 - Issue 1691: Align platforms supported with OpenSSL
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 387: fix ossl32 cache miss for cygwin
+		 - PR 382: Remove `--repeat until-pass:5` workaround for ASan tests.
+		 - PR 386: Add composite signatures to sigalg list & add code points.
+		 - PR 388: openssl provider support documentation update [skip ci]
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 363: Updates for clean builds across iOS / macOS / Android (all platforms)
+		 - PR 367: improve static build testing
+	- Open Issues:
+		 - Issue 389: conduct 'Full stack' performance testing using standard client software like 'curl' and nginx as the Web Server
+		 - Issue 375: Refactor code
+		 - Issue 372: How to separate the post-quantum algorithmic key and the classical key in the generated pkey
+		 - Issue 360: Getting message "too weak" when launching openssl server
+		 - Issue 358: oqs\_tlssig fails against OpenSSL 3.2.1
+		 - Issue 354: Adapt oqsprovider to liboqs version
+		 - Issue 353: Make CI using downstream integrations optional
+		 - Issue 351: Document & curate (O)IDs
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days:
+		 - PR 114: Falcon Update April 2024
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 271: Update test server with liboqs 0.10.0 release
+		 - Issue 270: Dont get Server Temp Key in openssl s\_client when testing
+		 - Issue 266: oqs-epiphany not working 
+		 - Issue 265: Not able to get OQS-Chromium browser working - https://openquantumsafe.org/applications/tls.html#chromium
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 110: liboqs benchmarking still running 0.9.0-rc1
+		 - Issue 101: Handshake performance of "reference code" vs "performance code"
+		 - Issue 97: Investigate performance drop in handshaking
+		 - Issue 96: Investigate memory use changes in handshaking
+		 - Issue 88: Change display logic 
+		 - Issue 74: Investigate gcc-11/OpenSSL3 profiling results on M1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days:
+		 - PR 73: Add curl and sudo to ubuntu-focal
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 40: A pipeline to release container image on github?
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 78: Importing OpenSSL keys and certificates
+		 - Issue 74: Kat-Vector-Falcon
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 257: chore(ci): bump the actions group with 1 update
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-04-09 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-04-09 - OQS status meeting - minutes.md
@@ -1,0 +1,96 @@
+# 2024-04-09 - OQS status meeting - minutes
+
+### Next meeting: Tuesday April 16, 2024 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+<!--### Next meeting: Tuesday April 16, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+## Attendees
+
+- Alex, Max (IBM)
+- Douglas, Pravek, Spencer (Waterloo)
+- Jason, Thomas (SandboxAQ)
+- Mark, Norm (Cisco)
+- Michael (independent)
+- Sara (Synopsys)
+- Vlad (softwareQ)
+
+## Agenda
+
+1. Status updates
+
+## 1. Status updates
+
+### OQS TSC
+
+Next OQS TSC meeting is tomorrow, April 10.
+
+### liboqs
+
+libjade integration: Pravek not sure what information to enter for the libjade implementation of Kyber in the CBOM. Pravek can ask Basil.
+
+Stateful hash-based signatures: Spencer has a call with Norm, Mark, Duc to finalize things before merge.  OpenSSL had a discussion about adding SHBS and we should talk to Nicola about this.
+
+What could be included in the next release?
+
+- stateful hash-based signatures
+- libjade implementation of Kyber
+- HQC AVX2 implementation update
+- Mayo
+
+Douglas to create milestone for 0.11.0.
+
+Eddy working on deterministic MLKEM key generation.
+
+### OpenSSL 3 Provider
+
+Michael has prepared a release candidate for oqs-provider 0.6.0.  Please take a look and provide feedback before a release at the end of the week.
+
+### BoringSSL
+
+No updates.
+
+### OpenSSH and libssh
+
+No updates.
+
+### OQS-Demos
+
+Spencer mentions that a student from Singapore expressed interest in nginx.
+
+Max asks about the status of various demos.  Douglas notes that we are overstretched on demos and many don't have someone interested in updating them.
+
+### Profiling
+
+Discussion about revamping profiling platform. It is shutdown at the moment.  Spencer prefers to do a major update to profiling rather than restart with a small bump to enable 0.10.0.  Michael highlights the need to identify goals of profiling.  Spencer to create some issues to discuss.  If it remains off, will need to disable it on www.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+No updates.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+Vlad to respond to issues.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.
+
+## 2. Other business
+
+Next week there will be presentations on OQS & PQCA at the Linux Foundation Open Source Summit in Seattle: Douglas, Max & Hart, and Alex & Max.

--- a/oqs-status-meetings/2024-04-16 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-04-16 - OQS status meeting - agenda.md
@@ -1,0 +1,290 @@
+# 2024-04-16 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday April 16 at 10:00 AM </span> US Eastern Time / 4:00 PM Central European / 7:00 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days:
+		 - PR 15: Add Vlad Gheorghiu to the TSC
+		 - PR 16: Add Vlad Gheorghiu to the roster
+	- Open PRs:
+		 - PR 14: Minutes from 2024-03-11 TSC meeting
+		 - PR 17: VOTE: License exemption for OQS-BoringSSL
+		 - PR 18: Add 20240410 minutes
+		 - PR 19: Add link to minutes and basic index
+	- Open Issues:
+		 - Issue 13: Does OQS-BoringSSL repository require a license exemption?
+		 - Issue 12: Create a voting procedure for the OQS TSC
+		 - Issue 11: Confirm mailing list openness and retention
+		 - Issue 10: Update config.yaml
+		 - Issue 8: FYI: open-quantum-safe/rust team has crates.io push access
+		 - Issue 5: CI in OQS: guidelines for responsible use
+		 - Issue 2: OQS sub projects: Which ones to drop for good
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1747: remove "maximum" words for most length fields
+		 - PR 1754: add compile\_commands.json to .gitignore
+	- Open PRs:
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1700: change from ninja and custom cmake target `run\_test` to using cmake & ctest.
+		 - PR 1707: Add MAYO signature scheme from NIST onramp
+		 - PR 1708: Create scorecard.yml (OpenSSF)
+		 - PR 1717: Proposed build wrapper script for static libs macOS / iOS / Android platforms
+		 - PR 1745: Integrate Kyber from libjade 
+	- Open Issues:
+		 - Issue 1753: Update CBOM to CycloneDX 1.6 specification
+		 - Issue 1750: Return value from OQS\_randombytes
+		 - Issue 1744: The "(maximum) length" words in `OQS\_SIG` and `OQS\_KEM` are misleading
+		 - Issue 1740: Add more test vectors for ML-KEM
+		 - Issue 1719: Improve algorithm versioning
+		 - Issue 1706: Add OpenSSF scorecard
+		 - Issue 1705: Handle out-of-memory errors gracefully
+		 - Issue 1691: Align platforms supported with OpenSSL
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 392: 0.6.0
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 363: Updates for clean builds across iOS / macOS / Android (all platforms)
+		 - PR 367: improve static build testing
+		 - PR 394: reverting to dev mode [skip ci]
+	- Open Issues:
+		 - Issue 396: Update SPECIFICATIONS.md
+		 - Issue 395: Linux x64 binary incorrect
+		 - Issue 389: conduct 'Full stack' performance testing using standard client software like 'curl' and nginx as the Web Server
+		 - Issue 375: Refactor code
+		 - Issue 372: How to separate the post-quantum algorithmic key and the classical key in the generated pkey
+		 - Issue 360: Getting message "too weak" when launching openssl server
+		 - Issue 358: oqs\_tlssig fails against OpenSSL 3.2.1
+		 - Issue 354: Adapt oqsprovider to liboqs version
+		 - Issue 353: Make CI using downstream integrations optional
+		 - Issue 351: Document & curate (O)IDs
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 272: Update test server build script: liboqs-0.10.0 & oqs-provider-0.6.0-rc1
+	- Open Issues:
+		 - Issue 271: Update test server with liboqs 0.10.0 release
+		 - Issue 270: Dont get Server Temp Key in openssl s\_client when testing
+		 - Issue 266: oqs-epiphany not working 
+		 - Issue 265: Not able to get OQS-Chromium browser working - https://openquantumsafe.org/applications/tls.html#chromium
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 110: liboqs benchmarking still running 0.9.0-rc1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days:
+		 - PR 42: Updated README.md
+		 - PR 41: Update README.md
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 40: A pipeline to release container image on github?
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days:
+		 - PR 84: Added whitespace
+		 - PR 83: Update virtualenv creation instructions
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 78: Importing OpenSSL keys and certificates
+		 - Issue 74: Kat-Vector-Falcon
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 258: chore(ci): bump KyleMayes/install-llvm-action from 1.9.0 to 2.0.2 in the actions group
+		 - PR 259: feat: update liboqs, add ml-kem / ml-dsa
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-04-16 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-04-16 - OQS status meeting - minutes.md
@@ -1,0 +1,90 @@
+# 2024-04-16 - OQS status meeting - minutes
+
+<!--### Next meeting: Tuesday April 16, 2024 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+### Next meeting: Tuesday April 23, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Attendees
+
+- Basil (IBM)
+- Douglas, Pravek, Spencer (Waterloo)
+- Hart (Linux Foundation)
+- Jason, Thomas (SandboxAQ)
+- Mark, Norm (Cisco)
+- Prem (AMD)
+- Sara (Synopsys)
+- Shubham Tatvamasi
+
+## Agenda
+
+1. Status updates
+
+## 1. Status updates
+
+### OQS TSC
+
+Minutes available from the TSC.
+
+### liboqs
+
+Stateful hash-based signatures: 
+
+- Jason would like to have an API to identify the algorithm from the public key. Norm notes that there are many variants of XMSS & LMS compared to other algorithms. Jason to introduce an issue to discuss.
+- Norm/Spencer/Duc/Mark met last Friday to discuss. Getting very close. Spencer making some changes to CMake flag for enabling signatures. Spencer doing some cleanup on CI failures.  Concerned about CI time.  Hart mentions that Ry can help us think about our CI usage.
+- Jason has a comment about SIG_free not releasing the right thing.
+
+### OpenSSL 3 Provider
+
+0.6.0 was released.
+
+Thomas: There might be an issue with output artifacts -- the .so / .a files on Intel contain nothing.  See issue #395. Basil was able to reproduce and has a potential fix.
+
+### BoringSSL
+
+No updates.
+
+### OpenSSH and libssh
+
+No updates.
+
+### OQS-Demos
+
+The test server was updated to 0.10.0.  Note that some ports have changed, which are documented in the JSON file.
+
+### Profiling
+
+Spencer stated discussion #112 about the direction of profiling; please contribute.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+No updates.
+
+**liboqs-java.**
+Spencer asks if this is maintained. Douglas says that we don't have an active maintainer.
+
+**liboqs-python.** 
+No updates.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.
+
+## 2. Other business
+
+Shubham is working on integrating a QRNG into one of the liboqs language wrappers and may be able to contribute it.
+
+Norm asks if anyone is familiar with the [ATIS testing framework](https://www.atis.org/initiatives/quantum/qscii-open-source-pqc-test-framework/) and [Qujata](https://github.com/att/qujata/tree/main).  Hart had a discussion with them a few weeks ago to learn more about what they're doing and see if they are willing to contribute.

--- a/oqs-status-meetings/2024-04-23 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-04-23 - OQS status meeting - agenda.md
@@ -1,0 +1,287 @@
+# 2024-04-23 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday April 23 at 12:30 PM </span> US Eastern Time / 6:30 PM Central European / 9:30 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days:
+		 - PR 17: VOTE: License exemption for OQS-BoringSSL
+		 - PR 19: Add link to minutes and basic index
+	- Open PRs:
+		 - PR 14: Minutes from 2024-03-11 TSC meeting
+		 - PR 18: Add 20240410 minutes
+	- Open Issues:
+		 - Issue 12: Create a voting procedure for the OQS TSC
+		 - Issue 11: Confirm mailing list openness and retention
+		 - Issue 10: Update config.yaml
+		 - Issue 8: FYI: open-quantum-safe/rust team has crates.io push access
+		 - Issue 5: CI in OQS: guidelines for responsible use
+		 - Issue 2: OQS sub projects: Which ones to drop for good
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1754: add compile\_commands.json to .gitignore
+		 - PR 1755: Stateful sigs: Rename keygen / sign option, add more tests, fix memory errors
+	- Open PRs:
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1700: change from ninja and custom cmake target `run\_test` to using cmake & ctest.
+		 - PR 1707: Add MAYO signature scheme from NIST onramp
+		 - PR 1708: Create scorecard.yml (OpenSSF)
+		 - PR 1717: Proposed build wrapper script for static libs macOS / iOS / Android platforms
+		 - PR 1745: Integrate Kyber from libjade 
+		 - PR 1758: Fix linking of test programs on msys
+	- Open Issues:
+		 - Issue 1761: Valgrind Massif Tool Breaks During Verify Operation of Falcon Algorithms on Raspberry Pi
+		 - Issue 1760: Document DCO utility and HOWTO
+		 - Issue 1753: Update CBOM to CycloneDX 1.6 specification
+		 - Issue 1750: Return value from OQS\_randombytes
+		 - Issue 1740: Add more test vectors for ML-KEM
+		 - Issue 1719: Improve algorithm versioning
+		 - Issue 1706: Add OpenSSF scorecard
+		 - Issue 1705: Handle out-of-memory errors gracefully
+		 - Issue 1691: Align platforms supported with OpenSSL
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 394: reverting to dev mode [skip ci]
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 363: Updates for clean builds across iOS / macOS / Android (all platforms)
+		 - PR 367: improve static build testing
+		 - PR 400: Add PKCS#12 test
+		 - PR 401: cpack x64 CI fix
+		 - PR 402: add caveat regarding OpenSSL installs [skip ci]
+	- Open Issues:
+		 - Issue 399: Weird hang-up?
+		 - Issue 396: Update SPECIFICATIONS.md
+		 - Issue 389: conduct 'Full stack' performance testing using standard client software like 'curl' and nginx as the Web Server
+		 - Issue 375: Refactor code
+		 - Issue 372: How to separate the post-quantum algorithmic key and the classical key in the generated pkey
+		 - Issue 360: Getting message "too weak" when launching openssl server
+		 - Issue 358: oqs\_tlssig fails against OpenSSL 3.2.1
+		 - Issue 354: Adapt oqsprovider to liboqs version
+		 - Issue 353: Make CI using downstream integrations optional
+		 - Issue 351: Document & curate (O)IDs
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 272: Update test server build script: liboqs-0.10.0 & oqs-provider-0.6.0-rc1
+	- Open Issues:
+		 - Issue 271: Update test server with liboqs 0.10.0 release
+		 - Issue 270: Dont get Server Temp Key in openssl s\_client when testing
+		 - Issue 266: oqs-epiphany not working 
+		 - Issue 265: Not able to get OQS-Chromium browser working - https://openquantumsafe.org/applications/tls.html#chromium
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 110: liboqs benchmarking still running 0.9.0-rc1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 40: A pipeline to release container image on github?
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 78: Importing OpenSSL keys and certificates
+		 - Issue 74: Kat-Vector-Falcon
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 258: chore(ci): bump KyleMayes/install-llvm-action from 1.9.0 to 2.0.2 in the actions group
+		 - PR 259: feat: update liboqs, add ml-kem / ml-dsa
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-04-23 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-04-23 - OQS status meeting - minutes.md
@@ -1,0 +1,97 @@
+# 2024-04-23 - OQS status meeting - minutes
+
+### Next meeting: Tuesday April 30, 2024 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+<!--### Next meeting: Tuesday April 23, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+## Attendees
+
+- Alex, Nigel (IBM)
+- Christian (MSR)
+- Douglas, Pravek, Spencer (Waterloo)
+- Jason (SandboxAQ)
+- Mark, Norm (Cisco)
+- Michael (independent)
+- Sara (Synopsys)
+- Vlad (softwareQ)
+
+## Agenda
+
+1. Report from Open Source Summit
+1. Status updates
+
+## 1. Report from Open Source Summit
+
+Last week there were 3 presentations on PQCA and OQS at the Linux Foundation's Open Source Summit in Seattle. Douglas introduced the PQCA and OQS in the main conference keynote. Hart and Max gave an overview of the PQCA, and Alex presented a demo of using OQS provider in HAProxy and curl.
+
+## 2. Status updates
+
+### OQS TSC
+
+Minutes available from the TSC.
+
+### liboqs
+
+Stateful hash-based signatures: Spencer is resolving some comments from Jason. Any other feedback welcome.
+
+Scorecard: Nigel has a PR with most of the scorecard functionality enabled; additional feedback welcome on [#1708](https://github.com/open-quantum-safe/liboqs/pull/1708).
+
+libjade: Pravek is fixing up some clang issues. Pravek points out that the code coming from libjade is CC0.  Douglas to email the Formosa project to ask about the status of their relicensing of libjade to Apache 2.  
+
+0.11.0: Michael asks about plans for 0.11.0. Douglas points to the [0.11.0 milestone](https://github.com/open-quantum-safe/liboqs/milestone/25).
+
+### OpenSSL 3 Provider
+
+Norm asks about the path for getting PQ code in OpenSSL.  Douglas explains that we have had some interactions with OpenSSL, but are blocked at the moment due to contributor license agreement complications.  Douglas has asked the LF lawyers if they can help with this, and will follow up again to try to get a reply.
+
+### BoringSSL
+
+No updates.
+
+### OpenSSH and libssh
+
+Christian notes that the NCCoE project is planning to do some SSH testing; Panos is taking the lead on this. What's the status of our SSH implementations?  Currently inactive; most recent comment was from Brian Jarvis saying he would see whether AWS can provide assistance in updating/maintaining these.
+
+### OQS-Demos
+
+Alex reports that he and Mariam plan to submit their [tutorials for HAProxy](https://developer.ibm.com/tutorials/awb-building-quantum-safe-web-applications/) to our demos repository eventually. Michael asks why not just make a Docker image? Alex says that the tutorial started out from an internal Docker image. Nigel notes that there can be value to readers from stepping through these things manually; so ultimate both a tutorial and a Docker image can be useful to different audiences.
+
+### Profiling
+
+Spencer looking for feedback on [discussion on what are we looking for in a benchmarking tool](https://github.com/open-quantum-safe/profiling/discussions/112).
+
+Michael asks if we want to remove old data? Spencer says that the old data does include a version number, so it is not false, though it is not up to date. Michael says we could add a disclaimer to the website for the old data. Douglas to create an issue to track this.
+
+### CI containers
+
+Nigel looking at updating images.
+
+Spencer notes that PQCA now has Github Enterprise status which should give us access to ARM runners; he will follow up on this.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+No updates.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+No updates.
+
+**liboqs-rust.**
+Vlad monitoring some issues.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.

--- a/oqs-status-meetings/2024-04-30 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-04-30 - OQS status meeting - agenda.md
@@ -1,0 +1,299 @@
+# 2024-04-30 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday April 30 at 10:00 AM </span> US Eastern Time / 4:00 PM Central European / 7:00 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days:
+		 - PR 21: Update visibility of www repo to public
+	- Open PRs:
+		 - PR 14: Minutes from 2024-03-11 TSC meeting
+		 - PR 18: Add 20240410 minutes
+	- Open Issues:
+		 - Issue 12: Create a voting procedure for the OQS TSC
+		 - Issue 11: Confirm mailing list openness and retention
+		 - Issue 10: Update config.yaml
+		 - Issue 8: FYI: open-quantum-safe/rust team has crates.io push access
+		 - Issue 5: CI in OQS: guidelines for responsible use
+		 - Issue 2: OQS sub projects: Which ones to drop for good
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1758: Fix linking of test programs on msys
+		 - PR 1762: restrict Windows platform support documentation [skip ci]
+		 - PR 1772: Test stateful sigs on arm64, s390x, and powerpc
+		 - PR 1769: Update README.md
+	- Open PRs:
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1700: change from ninja and custom cmake target `run\_test` to using cmake & ctest.
+		 - PR 1707: Add MAYO signature scheme from NIST onramp
+		 - PR 1708: Create scorecard.yml (OpenSSF)
+		 - PR 1717: Proposed build wrapper script for static libs macOS / iOS / Android platforms
+		 - PR 1745: Integrate Kyber from libjade 
+		 - PR 1773: Use OPENSSL\_cleanse if OpenSSL is used
+		 - PR 1774: Errors not printed out when OPENSSL\_NO\_STDIO is set
+		 - PR 1775: Fix README.md to work with Doxygen release 1.10.0
+	- Open Issues:
+		 - Issue 1770: Add C++ test to ci
+		 - Issue 1768: dlfcn required for windows build
+		 - Issue 1766: Overhauling OQS\_MEM functions
+		 - Issue 1765: Automated dependency checks/updates
+		 - Issue 1761: Valgrind Massif Tool Breaks During Verify Operation of Falcon Algorithms on Raspberry Pi
+		 - Issue 1760: Document DCO utility and HOWTO
+		 - Issue 1753: Update CBOM to CycloneDX 1.6 specification
+		 - Issue 1750: Return value from OQS\_randombytes
+		 - Issue 1740: Add more test vectors for ML-KEM
+		 - Issue 1719: Improve algorithm versioning
+		 - Issue 1706: Add OpenSSF scorecard
+		 - Issue 1705: Handle out-of-memory errors gracefully
+		 - Issue 1691: Align platforms supported with OpenSSL
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 401: cpack x64 CI fix
+		 - PR 402: add caveat regarding OpenSSL installs [skip ci]
+		 - PR 400: Add PKCS#12 test
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 363: Updates for clean builds across iOS / macOS / Android (all platforms)
+		 - PR 367: improve static build testing
+		 - PR 404: No unwanted error left in queue from OBJ\_create
+		 - PR 405: Extra parentheses removed
+	- Open Issues:
+		 - Issue 399: Weird hang-up?
+		 - Issue 396: Update SPECIFICATIONS.md
+		 - Issue 389: conduct 'Full stack' performance testing using standard client software like 'curl' and nginx as the Web Server
+		 - Issue 375: Refactor code
+		 - Issue 372: How to separate the post-quantum algorithmic key and the classical key in the generated pkey
+		 - Issue 360: Getting message "too weak" when launching openssl server
+		 - Issue 358: oqs\_tlssig fails against OpenSSL 3.2.1
+		 - Issue 354: Adapt oqsprovider to liboqs version
+		 - Issue 353: Make CI using downstream integrations optional
+		 - Issue 351: Document & curate (O)IDs
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 272: Update test server build script: liboqs-0.10.0 & oqs-provider-0.6.0-rc1
+	- Open Issues:
+		 - Issue 273: HAProxy
+		 - Issue 271: Update test server with liboqs 0.10.0 release
+		 - Issue 270: Dont get Server Temp Key in openssl s\_client when testing
+		 - Issue 266: oqs-epiphany not working 
+		 - Issue 265: Not able to get OQS-Chromium browser working - https://openquantumsafe.org/applications/tls.html#chromium
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 110: liboqs benchmarking still running 0.9.0-rc1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 76: Update doxygen on ubuntu-focal and ubuntu-jammy
+	- Open Issues:
+		 - Issue 75: Update CI image to contain more recent doxygen
+		 - Issue 74: Refresh ci-debian-buster container image used for build
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 40: A pipeline to release container image on github?
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 78: Importing OpenSSL keys and certificates
+		 - Issue 74: Kat-Vector-Falcon
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 258: chore(ci): bump KyleMayes/install-llvm-action from 1.9.0 to 2.0.2 in the actions group
+		 - PR 259: feat: update liboqs, add ml-kem / ml-dsa
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-04-30 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-04-30 - OQS status meeting - minutes.md
@@ -1,0 +1,96 @@
+# 2024-04-30 - OQS status meeting - minutes
+
+<!--### Next meeting: Tuesday April 30, 2024 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+### Next meeting: Tuesday May 7, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Attendees
+
+- Alex, Basil, Nigel (IBM)
+<!--- Christian (MSR)-->
+- Douglas, Pravek, Spencer (Waterloo)
+- Jason (SandboxAQ)
+- Mark, Norm (Cisco)
+- Prem (AMD)
+<!--- Michael (independent)-->
+- Sara (Synopsys)
+<!--- Vlad (softwareQ)-->
+
+## Agenda
+
+1. Status updates
+2. PQ Code Package updates
+
+## 1. Status updates
+
+### OQS TSC
+
+No updates.
+
+### liboqs
+
+Stateful hash-based signatures: Ready for final review with a goal of merging in the next week.
+
+MAYO: Basil working on changes upstream so it can be imported without too many patches. Aiming for being ready for review next week.
+
+libjade: Now Apache 2 licensed.  Pravek will update accordingly, then looking for more review/feedback. Q: Does the licensing change retroactively apply to past releases? 
+
+Scorecard: Documentation and cleanup still to be done. Nigel mentions that there's a proposal for a PQCA security workgroup and another proposal around CBOM, see https://github.com/PQCA/TAC/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+
+### OpenSSL 3 Provider
+
+No updates.
+
+### BoringSSL
+
+No updates.
+
+### OpenSSH and libssh
+
+No updates.
+
+### OQS-Demos
+
+271 can be closed.
+
+Douglas mentions 273 about HAProxy to Alex in case he's interested.
+
+### Profiling
+
+Spencer looking for feedback on [discussion on what are we looking for in a benchmarking tool](https://github.com/open-quantum-safe/profiling/discussions/112).
+
+### CI containers
+
+No updates.
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+No updates.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+No updates.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.
+
+## 2. PQ Code Package
+
+Nigel mentions that the PQ Code Package Technical Steering Committee will kick off next Thursday May 9, see https://github.com/pq-code-package/tsc/issues/44

--- a/oqs-status-meetings/2024-05-07 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-05-07 - OQS status meeting - agenda.md
@@ -1,0 +1,299 @@
+# 2024-05-07 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday May 07 at 12:30 PM </span> US Eastern Time / 6:30 PM Central European / 9:30 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Status updates
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days:
+		 - PR 23: Add oqs-bot to a team
+	- Open PRs:
+		 - PR 14: Minutes from 2024-03-11 TSC meeting
+		 - PR 18: Add 20240410 minutes
+		 - PR 22: Remove Amber Sprenkels from liboqs-rust
+	- Open Issues:
+		 - Issue 12: Create a voting procedure for the OQS TSC
+		 - Issue 11: Confirm mailing list openness and retention
+		 - Issue 10: Update config.yaml
+		 - Issue 8: FYI: open-quantum-safe/rust team has crates.io push access
+		 - Issue 5: CI in OQS: guidelines for responsible use
+		 - Issue 2: OQS sub projects: Which ones to drop for good
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1775: Fix README.md to work with Doxygen release 1.10.0
+		 - PR 1778: Add workflow dispatch to action
+	- Open PRs:
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1700: change from ninja and custom cmake target `run\_test` to using cmake & ctest.
+		 - PR 1707: Add MAYO signature scheme from NIST onramp
+		 - PR 1708: Create scorecard.yml (OpenSSF)
+		 - PR 1717: Proposed build wrapper script for static libs macOS / iOS / Android platforms
+		 - PR 1745: Integrate Kyber from libjade 
+		 - PR 1773: Use OPENSSL\_cleanse if OpenSSL is used
+		 - PR 1774: Errors not printed out when OPENSSL\_NO\_STDIO is set
+		 - PR 1782: Bump jinja2 from 3.1.3 to 3.1.4 in /scripts/copy\_from\_upstream
+	- Open Issues:
+		 - Issue 1781: What are STD algs?
+		 - Issue 1780: Update Ubuntu support to more current LTS version(s)
+		 - Issue 1770: Add C++ test to ci
+		 - Issue 1768: dlfcn required for windows build
+		 - Issue 1766: Overhauling OQS\_MEM functions
+		 - Issue 1765: Automated dependency checks/updates
+		 - Issue 1761: Valgrind Massif Tool Breaks During Verify Operation of Falcon Algorithms on Raspberry Pi
+		 - Issue 1760: Document DCO utility and HOWTO
+		 - Issue 1753: Update CBOM to CycloneDX 1.6 specification
+		 - Issue 1750: Return value from OQS\_randombytes
+		 - Issue 1740: Add more test vectors for ML-KEM
+		 - Issue 1719: Improve algorithm versioning
+		 - Issue 1706: Add OpenSSF scorecard
+		 - Issue 1705: Handle out-of-memory errors gracefully
+		 - Issue 1691: Align platforms supported with OpenSSL
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 301: Prepare 240 for merge
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 363: Updates for clean builds across iOS / macOS / Android (all platforms)
+		 - PR 367: improve static build testing
+		 - PR 404: No unwanted error left in queue from OBJ\_create
+		 - PR 405: Extra parentheses removed
+		 - PR 406: Disable Dilithium and SPHINCS+ sig algs by default
+		 - PR 409: Bump jinja2 from 3.1.3 to 3.1.4 in /oqs-template
+	- Open Issues:
+		 - Issue 399: Too many advertised sig algs cause TLS server hang-up
+		 - Issue 396: Update SPECIFICATIONS.md
+		 - Issue 389: conduct 'Full stack' performance testing using standard client software like 'curl' and nginx as the Web Server
+		 - Issue 375: Refactor code
+		 - Issue 372: How to separate the post-quantum algorithmic key and the classical key in the generated pkey
+		 - Issue 360: Getting message "too weak" when launching openssl server
+		 - Issue 358: oqs\_tlssig fails against OpenSSL 3.2.1
+		 - Issue 354: Adapt oqsprovider to liboqs version
+		 - Issue 353: Make CI using downstream integrations optional
+		 - Issue 351: Document & curate (O)IDs
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 115: Update to upstream 783ae72
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 272: Update test server build script: liboqs-0.10.0 & oqs-provider-0.6.0-rc1
+	- Open Issues:
+		 - Issue 273: HAProxy
+		 - Issue 270: Dont get Server Temp Key in openssl s\_client when testing
+		 - Issue 266: oqs-epiphany not working 
+		 - Issue 265: Not able to get OQS-Chromium browser working - https://openquantumsafe.org/applications/tls.html#chromium
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 110: liboqs benchmarking still running 0.9.0-rc1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days:
+		 - PR 76: Update doxygen on ubuntu-focal and ubuntu-jammy
+	- Open PRs:
+		 - PR 77: update go to 1.22.2
+	- Open Issues:
+		 - Issue 74: Refresh ci-debian-buster container image used for build
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 40: A pipeline to release container image on github?
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 78: Importing OpenSSL keys and certificates
+		 - Issue 74: Kat-Vector-Falcon
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 258: chore(ci): bump KyleMayes/install-llvm-action from 1.9.0 to 2.0.2 in the actions group
+		 - PR 259: feat: update liboqs, add ml-kem / ml-dsa
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates

--- a/oqs-status-meetings/2024-05-07 - OQS status meeting - minutes.md
+++ b/oqs-status-meetings/2024-05-07 - OQS status meeting - minutes.md
@@ -1,0 +1,121 @@
+# 2024-05-07 - OQS status meeting - minutes
+
+### Next meeting: Tuesday May 14, 2024 at 10:00am US Eastern time / 4:00pm Central European / 7:00am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+<!--### Next meeting: Tuesday May 7, 2024 at 12:30pm US Eastern time / 6:30pm Central European / 9:30am US Pacific time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)-->
+
+## Attendees
+
+- Alex, Mariam, Max, Nigel (IBM)
+<!--- Christian (MSR)-->
+- Douglas, Pravek, Spencer (Waterloo)
+- Jason (SandboxAQ)
+- JP (Quantum Resistant Ledger)
+- Mark, Norm (Cisco)
+- Michael (independent)
+<!--- Sara (Synopsys)-->
+<!--- Vlad (softwareQ)-->
+
+## Agenda
+
+1. Welcomes
+1. Status updates
+
+## 1. Welcomes
+
+Welcome to new participants joining the call: Mariam from IBM and JP from Quantum Resistant Ledger.
+
+## 2. Status updates
+
+### OQS TSC
+
+No updates.
+
+### liboqs
+
+Michael notes many build failures on the dashboard.
+
+1784: Documentation fixed.
+
+Scorecard: 
+
+- Nigel will rebase the PR.
+- Report highlights some missing checks that we should be doing, such as fuzzing.
+- Nigel to create new (or lift up existing) issues highlighted by the scorecad
+- Apparently this can be used to populate the Security tab on Github
+	- Michael suggests fixing as many issues as possible first so that out profile looks good
+- Who can help with tokens for triggering downstream builds? Ry?
+- Michael asks about constant time checks and why they're not part of the scorecard. Douglas responds that constant-time checks are very specific to cryptographic code, the scorecard is meant to be security best practices for more general open source code.
+
+Stateful hash-based signatures:
+
+- Douglas will review this week.
+
+Kyber from libjade:
+
+- Thanks to Michael for review
+- Licence changes have been applied to the tip of the libjade repository and will be propagated back by the end of the month
+- Michael asks if these implementations will be available by default. If so, how will users know which implementations are being used. Pravek to make an issue in provider to discuss how to surface this information.
+- Spencer asks about performance timing. Pravek doesn't have numbers available.
+
+Markdown linter: Pravek asks if there is a Markdown spec we should be pinned against.
+
+### OpenSSL 3 Provider
+
+410: Needs review.
+
+399: The problem is with another project, not our code.
+
+### BoringSSL
+
+No updates.
+
+### OpenSSH and libssh
+
+No updates.
+
+### OQS-Demos
+
+Mariam will start working on contributing changes / documentation for HAProxy.
+
+### Profiling
+
+No updates.
+
+### CI containers
+
+Ubuntu 22.04: 
+
+- We should prioritize updating this.
+- Pravek says we should document which subprojects use which containers.
+- Spencer asks if this could be automated.
+- Michael suggests Dependabot. Norm has has some experience with Dependabot and can take a look.
+
+
+### Language wrappers
+
+**liboqs-cpp.**
+No updates.
+
+**liboqs-dotnet.** 
+No updates.
+
+**liboqs-go.** 
+No updates.
+
+**liboqs-java.**
+No updates.
+
+**liboqs-python.** 
+No updates.
+
+**liboqs-rust.**
+No updates.
+
+### CI Containers
+
+No updates.
+
+### Website
+
+No updates.

--- a/oqs-status-meetings/2024-05-14 - OQS status meeting - agenda.md
+++ b/oqs-status-meetings/2024-05-14 - OQS status meeting - agenda.md
@@ -1,0 +1,320 @@
+# 2024-05-14 - OQS status meeting - agenda
+
+<span style="color: red;"> Tuesday May 14 at 10:00 AM </span> US Eastern Time / 4:00 PM Central European / 7:00 AM US Pacific Time on Zoom (https://uwaterloo.zoom.us/j/98064335970?pwd=U0tTZk84blBZTnptTXh0YmlZd1dOQT09)
+
+## Agenda
+
+1. Security issue for oqs-provider
+1. Call with Trail of Bits
+1. Status updates
+
+## OQS subprojects
+
+1. OQS Technical Steering Committee
+2. liboqs
+3. OQS-OpenSSL 3 provider
+4. OQS-BoringSSL
+5. OQS-OpenSSH
+6. OQS-libssh
+7. oqs-demos
+8. profiling
+9. ci-containers
+10. liboqs language wrappers: liboqs-C++, liboqs-.NET, liboqs-Go, liboqs-Java, liboqs-Python, liboqs-Rust
+11. www.openquantumsafe.org
+
+## Pre-meeting project reviews
+
+See project dashboard at: https://openquantumsafe.org/dashboard.html
+
+1. **<span style="color: red;">Build failures:<span style="color: red;">**
+
+	- **<span style="color: red;">liboqs CircleCI<span style="color: red;">**
+	- **<span style="color: red;">oqs-demos CircleCI<span style="color: red;">**
+	- **<span style="color: red;">liboqs-java CircleCI<span style="color: red;">**
+
+1. **OQS Technical Steering Committee**
+
+
+	- Merges in the last 7 days:
+		 - PR 22: Remove Amber Sprenkels from liboqs-rust
+	- Open PRs:
+		 - PR 14: Minutes from 2024-03-11 TSC meeting
+		 - PR 18: Add 20240410 minutes
+	- Open Issues:
+		 - Issue 25: Obtain funding for ARM CI GH runners
+		 - Issue 24: Decide procedure(s) to handle CI failures
+		 - Issue 12: Create a voting procedure for the OQS TSC
+		 - Issue 11: Confirm mailing list openness and retention
+		 - Issue 10: Update config.yaml
+		 - Issue 8: FYI: open-quantum-safe/rust team has crates.io push access
+		 - Issue 5: CI in OQS: guidelines for responsible use
+		 - Issue 2: OQS sub projects: Which ones to drop for good
+		 - Issue 1: OQS goal: non-committal research or production use?
+
+
+2. **liboqs**
+
+
+	- Merges in the last 7 days:
+		 - PR 1782: Bump jinja2 from 3.1.3 to 3.1.4 in /scripts/copy\_from\_upstream
+		 - PR 1784: Algorithm selection clarification
+	- Open PRs:
+		 - PR 1650: Add Stateful Signature (XMSS and LMS)
+		 - PR 1700: change from ninja and custom cmake target `run\_test` to using cmake & ctest.
+		 - PR 1707: Add MAYO signature scheme from NIST onramp
+		 - PR 1708: Create scorecard.yml (OpenSSF)
+		 - PR 1717: Proposed build wrapper script for static libs macOS / iOS / Android platforms
+		 - PR 1745: Integrate Kyber from libjade 
+		 - PR 1773: Use OPENSSL\_cleanse if OpenSSL is used
+		 - PR 1774: Errors not printed out when OPENSSL\_NO\_STDIO is set
+	- Open Issues:
+		 - Issue 1790: Zeroing internal state memory on heap
+		 - Issue 1789: Trigger downstream liboqs-python CI is failing
+		 - Issue 1788: Enable data independent timing on Apple Silicon
+		 - Issue 1787: Malformed generated `liboqs.pc` file
+		 - Issue 1786: Enhance test output
+		 - Issue 1785: Add documentation Markdown linter to CI
+		 - Issue 1783: Remove unnecessary downstream CI
+		 - Issue 1780: Update Ubuntu support to more current LTS version(s)
+		 - Issue 1770: Add C++ test to ci
+		 - Issue 1768: dlfcn required for windows build
+		 - Issue 1766: Overhauling OQS\_MEM functions
+		 - Issue 1765: Automated dependency checks/updates
+		 - Issue 1761: Valgrind Massif Tool Breaks During Verify Operation of Falcon Algorithms on Raspberry Pi
+		 - Issue 1760: Document DCO utility and HOWTO
+		 - Issue 1753: Update CBOM to CycloneDX 1.6 specification
+		 - Issue 1750: Return value from OQS\_randombytes
+		 - Issue 1748: LibOQS CMake fails with cmake 3.28.3
+		 - Issue 1740: Add more test vectors for ML-KEM
+		 - Issue 1719: Improve algorithm versioning
+		 - Issue 1706: Add OpenSSF scorecard
+		 - Issue 1705: Handle out-of-memory errors gracefully
+		 - Issue 1691: Align platforms supported with OpenSSL
+		 - Issue 1678: Investigate BIKE failures on x86
+		 - Issue 1674: Expand weekly test runs to platforms other than x86\_64 / Linux
+		 - Issue 1673: Clearly document KAT sources
+		 - Issue 1639: CI tooling for variable-time operations on some platforms
+		 - Issue 1623: Update PR approval requirements
+		 - Issue 1619: Introduce constant time build variable
+		 - Issue 1606: OQS\_SHA*\_sha***\_ API does not support arbitrary length updates
+		 - Issue 1596: Update HQC AVX2 implementation
+		 - Issue 1540: Environment-specific Classic McEliece constant-time leaks
+		 - Issue 1514: Review & automate license management
+		 - Issue 1494: Use modern CMake syntax
+		 - Issue 1474: Multithreading tests
+		 - Issue 1466: Integrate Kyber implementation from libjade
+		 - Issue 1456: Add telltale error handling in void functions
+		 - Issue 1437: CC0 license is an obstacle
+		 - Issue 1416: RISC-V support
+		 - Issue 1408: Test all scripts
+		 - Issue 1366: Run clang's MemorySanitizer in CI
+		 - Issue 1233: Common code for s390x / ppc64le, Windows
+		 - Issue 1215: Add fuzzing testing
+		 - Issue 1206: Adding a DeriveKeyPair functionality
+		 - Issue 1199: WASM compatibillity
+		 - Issue 1185: Adding a build variable to specify armv8 version
+		 - Issue 1138: Correct OQS\_MINIMAL\_BUILD logic when introducing new optimizations
+		 - Issue 1098: Add stateful hash-based signatures
+		 - Issue 1083: Enabling more compiler warnings
+		 - Issue 910: Establish interop with Circl
+		 - Issue 167: Code coverage
+
+
+3. **OQS-OpenSSL 3 provider**
+
+
+	- Merges in the last 7 days:
+		 - PR 410: Fix CI (Add Ubuntu 24 support)
+		 - PR 409: Bump jinja2 from 3.1.3 to 3.1.4 in /oqs-template
+		 - PR 405: Extra parentheses removed
+		 - PR 404: No unwanted error left in queue from OBJ\_create
+	- Open PRs:
+		 - PR 294: Fix #272: check `c\_obj\_create` error code for `OBJ\_R\_OID\_EXISTS`.
+		 - PR 316: Generate code coverage using source-based LLVM code coverage.
+		 - PR 363: Updates for clean builds across iOS / macOS / Android (all platforms)
+		 - PR 367: improve static build testing
+		 - PR 412: MSVC C2059 error when no signature is enabled
+	- Open Issues:
+		 - Issue 399: Too many advertised sig algs cause TLS server hang-up
+		 - Issue 396: Update SPECIFICATIONS.md
+		 - Issue 389: conduct 'Full stack' performance testing using standard client software like 'curl' and nginx as the Web Server
+		 - Issue 375: Refactor code
+		 - Issue 372: How to separate the post-quantum algorithmic key and the classical key in the generated pkey
+		 - Issue 360: Getting message "too weak" when launching openssl server
+		 - Issue 358: oqs\_tlssig fails against OpenSSL 3.2.1
+		 - Issue 354: Adapt oqsprovider to liboqs version
+		 - Issue 353: Make CI using downstream integrations optional
+		 - Issue 351: Document & curate (O)IDs
+		 - Issue 331: Supporting Stateful Signatures
+		 - Issue 328: Automate testing for backlevel liboqs variants
+		 - Issue 319: how to integrate provider with openssl no-shared static build
+		 - Issue 293: Document platforms supported
+		 - Issue 289: Enable CI runs for specific upstream tags
+		 - Issue 279: Evaluate liboqs reference in dynamic linking situations
+		 - Issue 272: Race condition with `c\_obj\_create`.
+		 - Issue 269: What hybrid key concepts should be supported?
+		 - Issue 251: Using PKCS#7 OpenSSL API
+		 - Issue 248: Move off CircleCI
+		 - Issue 239: Missing support for hash-n-sign
+		 - Issue 228: Eliminate use of jinja2
+		 - Issue 227: Create PR for brew when oqsprovider is notable enough
+		 - Issue 162: Improve use of IDs in ERR\_raise()
+		 - Issue 155: Improve (heap) memory consumption
+		 - Issue 154: QSC encoder library build loses cross-compilation settings
+		 - Issue 94: Make available binaries
+		 - Issue 81: Faster error-exit
+		 - Issue 17: Hybrid KEM: more combiners, more abstraction
+
+
+4. **OQS-BoringSSL**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 115: Update to upstream 783ae72
+		 - Issue 108: Review project status
+		 - Issue 96: Add OpenSSL interop testing
+		 - Issue 81: Introduce TLS\_DEFAULT\_GROUPS env var
+		 - Issue 77: Automate hybrid strength assignment
+		 - Issue 60: Add some OQS tests to x509/x509\_test.cc and evp/evp\_test.cc
+
+
+5. **OQS-OpenSSH**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 153: Fix version number
+		 - Issue 152: Displayed version is not updated for 2023-10 release since 2022-08
+		 - Issue 150: Memory leaks in oqs ecdh path
+		 - Issue 149: Merge conflict markers in ssh\_config.5
+		 - Issue 145: New "permanent temporary" P256+Kyber768 IANA codepoint support in OQS OpenSSH
+		 - Issue 135: Migrate to OpenSSH 9.2
+		 - Issue 90: OpenSSH 8.4: Figure out if the regression suite can be augmented
+		 - Issue 89: Figure out why certain tests are failing.
+		 - Issue 24: Enable PQ certs
+
+
+6. **OQS-libssh**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 21: pkd\_hello test suite breaks on Ubuntu 22.04 host
+
+
+7. **oqs-demos**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 272: Update test server build script: liboqs-0.10.0 & oqs-provider-0.6.0-rc1
+		 - PR 275: reduce further and document better support level of single integrations
+	- Open Issues:
+		 - Issue 273: HAProxy
+		 - Issue 270: Dont get Server Temp Key in openssl s\_client when testing
+		 - Issue 266: oqs-epiphany not working 
+		 - Issue 265: Not able to get OQS-Chromium browser working - https://openquantumsafe.org/applications/tls.html#chromium
+		 - Issue 261: Add QUIC support
+		 - Issue 255: Wireshark Docker Build Fails with WolfSSL Due to Undeclared 'QSC\_SIG\_CPS' Variable
+		 - Issue 230: Fix integrations to specific commits?
+		 - Issue 229: Cannot switch off OQS\_HAVE\_GETENTROPY, OQS\_HAVE\_EXPLICIT\_BZERO
+		 - Issue 226: haproxy build failed on MacOS 
+		 - Issue 216: add into edk2 openssllib
+		 - Issue 213: Create cross-platform docker images in github
+		 - Issue 200: Path to a NodeJS demo
+		 - Issue 182: replace oqs-openssl111
+		 - Issue 171: Create CI/docker push for unbound
+		 - Issue 92: Add OQS to libnss (enabling loading quantum safe certificate into Chromium)
+
+
+8. **profiling**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 110: liboqs benchmarking still running 0.9.0-rc1
+
+
+9. **ci-containers**
+
+
+	- Merges in the last 7 days:
+		 - PR 77: update go to 1.22.2
+		 - PR 79: Update Go to 1.22.3 and fix errors
+		 - PR 80: set env vars GOROOT and PATH explicitly
+		 - PR 84: Adding Ubuntu latest
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 81: Update Container build CI
+		 - Issue 78: Track container usage
+		 - Issue 74: Refresh ci-debian-buster container image used for build
+
+
+10. **liboqs-C++**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues: None
+
+
+11. **liboqs-.NET**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 28: fix Classic McEliece stackoverflow issue by running unit tests with larger stack
+
+
+12. **liboqs-Go**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 40: A pipeline to release container image on github?
+
+
+13. **liboqs-Java**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 20: Tag 0.1.1
+		 - Issue 1: Enable build on Windows
+
+
+14. **liboqs-Python**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs: None
+	- Open Issues:
+		 - Issue 86: Building for MacOS M1 (Arm)
+		 - Issue 78: Importing OpenSSL keys and certificates
+		 - Issue 74: Kat-Vector-Falcon
+
+
+15. **liboqs-Rust**
+
+
+	- Merges in the last 7 days: None.
+	- Open PRs:
+		 - PR 258: chore(ci): bump KyleMayes/install-llvm-action from 1.9.0 to 2.0.2 in the actions group
+		 - PR 259: feat: update liboqs, add ml-kem / ml-dsa
+	- Open Issues:
+		 - Issue 216: Don't recompile oqs everytime cargo build is invoked
+		 - Issue 202: expose `OQS\_PERMIT\_UNSUPPORTED\_ARCHITECTURE`, for example as cargo feature
+		 - Issue 137: Support RustCrypto KEM and Signature traits
+		 - Issue 131: WASM compatibility
+		 - Issue 127: ARMv8 compatibility: CI and cross-compiling?
+
+
+16. **www.openquantumsafe.org** : No updates


### PR DESCRIPTION
Alex B from IBM suggested that I post the agendas and minutes from the OQS weekly status calls on Github.