### PR TITLE
Add @ajbozarth to triage members

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -59,6 +59,7 @@ teams:
   - dstebila
   members:
   - planetf1
+  - ajbozarth
 - name: tsc
   maintainers:
   - baentsch


### PR DESCRIPTION
As recommend during today's oqs call, I believe this will give me the correct access to edit projects, labels, and assignees in the oqs-demos repo (and based on this config it seems every OQS repo)