### PR TITLE
Upgrade access for OQS project non--core-team members

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -112,6 +112,7 @@ repositories:
     ashman-p: write
     cothan: write
     thomwiggers: write
+    jplomas: read
   teams:
     bots: write
     core: write

--- a/config.yaml
+++ b/config.yaml
@@ -56,6 +56,11 @@ teams:
 - name: oqs-provider-committers
   maintainers:
   - thb-sb
+- name: read
+  maintainers:
+  - dstebila
+  members:
+  - jplomas
 - name: rust
   maintainers:
   - thomwiggers
@@ -112,12 +117,12 @@ repositories:
     ashman-p: write
     cothan: write
     thomwiggers: write
-    jplomas: read
   teams:
     bots: write
     core: write
     liboqs-committers: write
     liboqs-maintainers: maintain
+    read: read
     triage: triage
     tsc: read
   visibility: public

--- a/config.yaml
+++ b/config.yaml
@@ -57,7 +57,6 @@ teams:
   maintainers:
   - baentsch
   members:
-  - baentsch
   - bhess
   - feventura
   - iyanmv

--- a/config.yaml
+++ b/config.yaml
@@ -56,6 +56,9 @@ teams:
 - name: oqs-provider-committers
   maintainers:
   - thb-sb
+  members:
+  - feventura
+  - iyanmv
 - name: read
   maintainers:
   - dstebila

--- a/config.yaml
+++ b/config.yaml
@@ -53,12 +53,18 @@ teams:
   - dstebila
   members:
   - geedo0
+- name: oqs-provider-codeowners
+  maintainers:
+  - baentsch
+  members:
+  - baentsch
+  - bhess
+  - feventura
+  - iyanmv
+  - thb-sb
 - name: oqs-provider-committers
   maintainers:
   - thb-sb
-  members:
-  - feventura
-  - iyanmv
 - name: read
   maintainers:
   - dstebila
@@ -216,6 +222,7 @@ repositories:
     core: write
     liboqs-committers: write
     liboqs-maintainers: maintain
+    oqs-provider-codeowners: write
     oqs-provider-committers: write
     triage: triage
     tsc: read

--- a/config.yaml
+++ b/config.yaml
@@ -48,6 +48,11 @@ teams:
   - dstebila
   members:
   - kevinmkane
+- name: openssh-committers
+  maintainers:
+  - dstebila
+  members:
+  - geedo0
 - name: oqs-provider-committers
   maintainers:
   - thb-sb
@@ -60,6 +65,7 @@ teams:
   members:
   - planetf1
   - ajbozarth
+  - geedo0
 - name: trail-of-bits
   maintainers:
   - SWilson4
@@ -177,6 +183,7 @@ repositories:
   teams:
     bots: write
     core: write
+    openssh-committers: write
     triage: triage
     tsc: read
   visibility: public


### PR DESCRIPTION
- Give @geedo0 write access to https://github.com/open-quantum-safe/openssh. Gerardo is actively working on bringing the openssh project up to date.
- Give @geedo0 triage access across OQS projects.
- Give @jplomas read access to liboqs, and hence the ToB project board. JP is a regular attendee on liboqs status calls.