### PR TITLE
Give @SWilson4 write permissions on tsc repo to push meeting minutes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,6 +67,9 @@ teams:
 - name: libssh-maintainers
   maintainers:
   - dstebila
+- name: minute-takers
+  maintainers:
+  - SWilson4
 - name: openssh-committers
   maintainers:
   - dstebila
@@ -263,6 +266,7 @@ repositories:
 - name: tsc
   teams:
     core: read
+    minute-takers: write
     triage: triage
     tsc: write
   visibility: public


### PR DESCRIPTION
This would allow me to upload meeting minutes without requiring a TSC member to approve the PR.

I'll leave it to @open-quantum-safe/tsc to decide whether or not this is appropriate.