### PR TITLE
Give oqs-bot access to liboqs-cpp and liboqs-go

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -161,6 +161,7 @@ repositories:
   visibility: public
 - name: liboqs-cpp
   teams:
+    bots: write
     core: write
     liboqs-cpp-admins: admin
     triage: triage
@@ -179,6 +180,7 @@ repositories:
   visibility: public
 - name: liboqs-go
   teams:
+    bots: write
     core: maintain
     liboqs-go-admins: admin
     triage: triage


### PR DESCRIPTION
This will allow CI for those repos to be triggered from liboqs CI.