### PR TITLE
Update github account for thb

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -80,7 +80,7 @@ teams:
   - Martyrshot
   - pi-314159
   - planetf1
-  - thb-sb
+  - zadlg
   - thomwiggers
 
 # Technical Steering Committee
@@ -94,7 +94,7 @@ teams:
   - bhess
   - brian-jarvis-aws
   - christianpaquin
-  - thb-sb
+  - zadlg
   - vsoftco
 
 # liboqs Maintainers
@@ -144,7 +144,7 @@ teams:
   members:
   - bhess
   - christianpaquin
-  - thb-sb
+  - zadlg
 # oqs-provider CODEOWNERS
 # https://github.com/open-quantum-safe/oqs-provider/blob/main/.github/CODEOWNERS
 - name: oqs-provider-codeowners
@@ -156,7 +156,7 @@ teams:
   - feventura
   - iyanmv
   - jplomas
-  - thb-sb
+  - zadlg
 
 # boringssl Maintainers
 # TODO: provide "source of truth"


### PR DESCRIPTION
Thomas Bailleux has updated to a new GitHub account.

Old account: thb-sb

New account: zadlg

Unconditionally, changes to `config.yaml` must
- [x] be approved by 2 members of the OQS TSC
- [x] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [ ] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [ ] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [ ] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations