### PR TITLE
Document dependency on liboqs-rust Release Managers team

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -222,7 +222,7 @@ teams:
   - thomwiggers
 # liboqs-rust Release Managers
 # TODO: provide "source of truth"
-# This team is tied to permissions on Crates.io: https://crates.io/teams/github:open-quantum-safe:rust
+# This team is tied to permissions on Crates.io: https://crates.io/teams/github:open-quantum-safe:liboqs-rust-release-managers
 - name: liboqs-rust-release-managers
   maintainers:
   - thomwiggers

--- a/config.yaml
+++ b/config.yaml
@@ -222,6 +222,7 @@ teams:
   - thomwiggers
 # liboqs-rust Release Managers
 # TODO: provide "source of truth"
+# This team is tied to permissions on Crates.io: https://crates.io/teams/github:open-quantum-safe:rust
 - name: liboqs-rust-release-managers
   maintainers:
   - thomwiggers

--- a/config.yaml
+++ b/config.yaml
@@ -223,8 +223,7 @@ teams:
 # liboqs-rust Release Managers
 # TODO: provide "source of truth"
 # This team is tied to permissions on Crates.io: https://crates.io/teams/github:open-quantum-safe:rust
-# It is named "rust" instead of "liboqs-rust-release-managers" in order to not break the existing Crates.io config.
-- name: rust
+- name: liboqs-rust-release-managers
   maintainers:
   - thomwiggers
 

--- a/config.yaml
+++ b/config.yaml
@@ -378,8 +378,8 @@ repositories:
   teams:
     oqs-admins: admin
     liboqs-rust-maintainers: admin
-    # The release managers team is named "rust" for compatibility with Crates.io
-    rust: maintain
+    # Note that this team name is relied on by `crates.io`
+    liboqs-rust-release-managers: maintain
     oqs-committers: write
     oqs-contributors: triage
     bots: write

--- a/config.yaml
+++ b/config.yaml
@@ -223,7 +223,8 @@ teams:
 # liboqs-rust Release Managers
 # TODO: provide "source of truth"
 # This team is tied to permissions on Crates.io: https://crates.io/teams/github:open-quantum-safe:rust
-- name: liboqs-rust-release-managers
+# It is named "rust" instead of "liboqs-rust-release-managers" in order to not break the existing Crates.io config.
+- name: rust
   maintainers:
   - thomwiggers
 
@@ -378,7 +379,8 @@ repositories:
   teams:
     oqs-admins: admin
     liboqs-rust-maintainers: admin
-    liboqs-rust-release-managers: maintain
+    # The release managers team is named "rust" for compatibility with Crates.io
+    rust: maintain
     oqs-committers: write
     oqs-contributors: triage
     bots: write


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
See https://github.com/open-quantum-safe/tsc/pull/77#discussion_r1780535657. Marked as draft pending input from @thomwiggers on whether or not the name change (liboqs-rust-release-managers -> rust) is necessary.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- As changes to the file `config.yaml` are particularly sensitive because they change GH permissions throughout the project, the following rules apply to PRs affecting this file -->

Unconditionally, changes to `config.yaml` must
- [ ] be approved by 2 members of the OQS TSC
- [ ] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [ ] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [ ] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [ ] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations

