### PR TITLE
Add security managers to repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -428,6 +428,7 @@ repositories:
 - name: liboqs-cupqc
   teams:
     liboqs-cupqc-maintainers: maintain
+    tsc: read
   visibility: private
 
 # TODO: This project is dead and probably should be read-only.


### PR DESCRIPTION
This will stop flapping in CLOWarden

The security managers (the TSC) need read access to all repos

Unconditionally, changes to `config.yaml` must
- [x] be approved by 2 members of the OQS TSC
- [x] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [x] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [x] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [x] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations

