### PR TITLE
VOTE: Add Spencer Wilson to OQS TSC and appoint as OQS rep to PQCA TAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ The role and responsibilities of the TSC are described in the [Technical Charter
 
 - Norman Ashley (Cisco)
 - Michael Baentsch (independent contributor)
-- Thomas Bailleux (SandboxAQ) – TSC representative to PQCA TAC
+- Thomas Bailleux (independent contributor)
 - Vlad Gheorghiu (softwareQ Inc.)
 - Basil Hess (IBM Research) – TSC vice chair
 - Brian Jarvis (AWS)
 - Christian Paquin (Microsoft Research)
 - Douglas Stebila (University of Waterloo) – TSC chair
+- Spencer Wilson (University of Waterloo) – OQS representative to PQCA TAC
 
 ## Communication Channels
 


### PR DESCRIPTION
This pull request is a TSC vote to add Spencer Wilson to the OQS TSC and appoint him to be the OQS representative to the PQCA TAC.  

Voting members for this issue:
- @ashman-p 
- @baentsch 
- @zadlg 
- @vsoftco 
- @bhess 
- @brian-jarvis-aws 
- @christianpaquin 

To vote in favour, please either give a positive review or a thumbs up on this comment. To vote against, please give a thumbs down on this comment. Quorum is 5 votes.