### PR TITLE
Create security-managers team

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,7 @@ teams:
 - name: oqs-admins
   maintainers:
   - ryjones
+
 # write access on all technical projects
 - name: bots
   maintainers:
@@ -20,6 +21,18 @@ teams:
   - dstebila
   members:
   - SWilson4
+
+# Security managers
+- name: security-managers
+  maintainers:
+  - dstebila
+  members:
+  - baentsch
+  - bhess
+  - brian-jarvis-aws
+  - praveksharma
+  - SWilson4
+
 # access to Trail of Bits audit project board
 - name: trail-of-bits
   maintainers:
@@ -246,12 +259,14 @@ repositories:
 - name: .github
   teams:
     oqs-admins: admin
+    security-managers: read
     tsc: read
   visibility: public
 
 - name: tsc
   teams:
     oqs-admins: admin
+    security-managers: read
     tsc: write
     minute-takers: write
   visibility: public
@@ -264,6 +279,7 @@ repositories:
     liboqs-committers: write
     liboqs-codeowners: write
     oqs-contributors: triage
+    security-managers: read
     bots: write
     tsc: read
   visibility: public
@@ -277,6 +293,7 @@ repositories:
     oqs-provider-codeowners: write
     oqs-contributors: triage
     bots: write
+    security-managers: read
     tsc: read
   visibility: public
 
@@ -287,6 +304,7 @@ repositories:
     oqs-release-managers: maintain
     oqs-committers: write
     oqs-contributors: triage
+    security-managers: read
     bots: write
     tsc: read
   visibility: public
@@ -298,6 +316,7 @@ repositories:
     openssh-release-managers: maintain
     oqs-committers: write
     oqs-contributors: triage
+    security-managers: read
     bots: write
     tsc: read
   visibility: public
@@ -309,6 +328,7 @@ repositories:
     oqs-release-managers: maintain
     oqs-committers: write
     oqs-contributors: triage
+    security-managers: read
     bots: write
     tsc: read
   visibility: public
@@ -320,6 +340,7 @@ repositories:
     oqs-release-managers: maintain
     oqs-committers: write
     oqs-contributors: triage
+    security-managers: read
     bots: write
     tsc: read
   visibility: public
@@ -331,6 +352,7 @@ repositories:
     oqs-release-managers: maintain
     oqs-committers: write
     oqs-contributors: triage
+    security-managers: read
     bots: write
     tsc: read
   visibility: public
@@ -342,6 +364,7 @@ repositories:
     oqs-release-managers: maintain
     oqs-committers: write
     oqs-contributors: triage
+    security-managers: read
     bots: write
     tsc: read
   visibility: public
@@ -354,6 +377,7 @@ repositories:
     oqs-committers: write
     oqs-contributors: triage
     bots: write
+    security-managers: read
     tsc: read
   visibility: public
 
@@ -365,6 +389,7 @@ repositories:
     oqs-committers: write
     oqs-contributors: triage
     bots: write
+    security-managers: read
     tsc: read
   visibility: public
 
@@ -375,6 +400,7 @@ repositories:
     liboqs-python-release-managers: maintain
     oqs-committers: write
     oqs-contributors: triage
+    security-managers: read
     bots: write
     tsc: read
   visibility: public
@@ -388,6 +414,7 @@ repositories:
     oqs-committers: write
     oqs-contributors: triage
     bots: write
+    security-managers: read
     tsc: read
   visibility: public
 
@@ -399,6 +426,7 @@ repositories:
     oqs-committers: write
     oqs-contributors: triage
     bots: write
+    security-managers: read
     tsc: read
   visibility: public
 
@@ -409,6 +437,7 @@ repositories:
     oqs-release-managers: maintain
     oqs-committers: write
     oqs-contributors: triage
+    security-managers: read
     bots: write
     tsc: read
   visibility: public
@@ -421,6 +450,7 @@ repositories:
     oqs-committers: write
     oqs-contributors: triage
     bots: write
+    security-managers: read
     tsc: read
   visibility: public
 
@@ -429,6 +459,7 @@ repositories:
 - name: liboqs-cupqc
   teams:
     liboqs-cupqc-maintainers: maintain
+    security-managers: read
     tsc: read
   visibility: private
 
@@ -436,5 +467,6 @@ repositories:
 - name: openssl
   teams:
     oqs-admins: admin
+    security-managers: read
     tsc: read
   visibility: public


### PR DESCRIPTION
Create a security-managers team.

Fixes #112 

<!-- As changes to the file `config.yaml` are particularly sensitive because they change GH permissions throughout the project, the following rules apply to PRs affecting this file -->

Unconditionally, changes to `config.yaml` must
- [x] be approved by 2 members of the OQS TSC
- [x] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [x] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [x] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [x] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations