### PR TITLE
Add members to the liboqs-rust teams

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -238,12 +238,22 @@ teams:
 - name: liboqs-rust-maintainers
   maintainers:
   - thomwiggers
+  members:
+  - baentsch
+  - dstebila
+  - vsoftco
 # liboqs-rust Release Managers
 # TODO: provide "source of truth"
 # This team is tied to permissions on Crates.io: https://crates.io/teams/github:open-quantum-safe:liboqs-rust-release-managers
 - name: liboqs-rust-release-managers
   maintainers:
   - thomwiggers
+  members:
+  - baentsch
+  - dstebila
+  - praveksharma
+  - SWilson4
+  - vsoftco
 
 # The following is a private project intentionally hidden from view.
 # Contact praveksharma for details.

--- a/config.yaml
+++ b/config.yaml
@@ -239,8 +239,8 @@ teams:
   maintainers:
   - thomwiggers
   members:
-  - baentsch
   - dstebila
+  - SWilson4
   - vsoftco
 # liboqs-rust Release Managers
 # TODO: provide "source of truth"
@@ -249,7 +249,6 @@ teams:
   maintainers:
   - thomwiggers
   members:
-  - baentsch
   - dstebila
   - praveksharma
   - SWilson4


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
This reduces dependence/load on @thomwiggers, who is not able to contribute to OQS to the same degree as before.

I added the default list of maintainers/release managers while keeping Thom on both teams.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- As changes to the file `config.yaml` are particularly sensitive because they change GH permissions throughout the project, the following rules apply to PRs affecting this file -->

Unconditionally, changes to `config.yaml` must
- [ ] be approved by 2 members of the OQS TSC
- [x] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [x] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [x] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [ ] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations

