### PR TITLE
Create new liboqs-cupqc-meta repo and delete old liboqs-cupqs team/repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -448,6 +448,19 @@ repositories:
     tsc: read
   visibility: public
 
+- name: liboqs-cupqc-meta
+  teams:
+    oqs-admins: admin
+    liboqs-maintainers: admin
+    oqs-release-managers: maintain
+    liboqs-committers: write
+    liboqs-codeowners: write
+    oqs-contributors: triage
+    security-managers: read
+    bots: write
+    tsc: read
+  visibility: public
+
 # No Release Managers team as there are no releases for this project.
 - name: www
   teams:

--- a/config.yaml
+++ b/config.yaml
@@ -251,16 +251,6 @@ teams:
   - SWilson4
   - vsoftco
 
-# The following is a private project intentionally hidden from view.
-# Contact praveksharma for details.
-- name: liboqs-cupqc-maintainers
-  maintainers:
-   - praveksharma
-  members:
-   - ydoroz
-   - stevenireeves
-   - neil-lindquist
-
 repositories:
 - name: .github
   teams:
@@ -472,15 +462,6 @@ repositories:
     security-managers: read
     tsc: read
   visibility: public
-
-# The following is a private project intentionally hidden from view.
-# Contact praveksharma for details.
-- name: liboqs-cupqc
-  teams:
-    liboqs-cupqc-maintainers: maintain
-    security-managers: read
-    tsc: read
-  visibility: private
 
 # TODO: This project is dead and probably should be read-only.
 - name: openssl


### PR DESCRIPTION
The integration of cuPQC's ML-KEM into liboqs is now complete. This PR does two things:

- Create a new public repo liboqs-cupqc-meta to store the metadata needed by liboqs' copy_from_upstream mechanism; this repo has the same access rights as the liboqs repo. This data is presently stored in a private repo: https://github.com/praveksharma/cupqc-mlkem. The possibility of storing this data in a Nvidia repo was discussed but this solution is more feasible and straightforward to implement.
- Deletes the private repo liboqs-cupqc (and associated maintainers team) since the repo is no longer needed.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- As changes to the file `config.yaml` are particularly sensitive because they change GH permissions throughout the project, the following rules apply to PRs affecting this file -->

Unconditionally, changes to `config.yaml` must
- [ ] be approved by 2 members of the OQS TSC
- [ ] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [ ] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [ ] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [ ] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations

