### PR TITLE
Add OQS-Provider Maintainer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -150,11 +150,13 @@ teams:
 - name: oqs-provider-maintainers
   maintainers:
   - baentsch
+  - ashman-p
 # oqs-provider Committers
 # https://github.com/open-quantum-safe/oqs-provider/blob/main/GOVERNANCE.md#committers-1
 - name: oqs-provider-committers
   maintainers:
   - baentsch
+  - ashman-p
   members:
   - bhess
   - christianpaquin
@@ -164,6 +166,7 @@ teams:
 - name: oqs-provider-codeowners
   maintainers:
   - baentsch
+  - ashman-p
   members:
   - alexrow
   - bhess


### PR DESCRIPTION
An additional maintainer

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- As changes to the file `config.yaml` are particularly sensitive because they change GH permissions throughout the project, the following rules apply to PRs affecting this file -->

Unconditionally, changes to `config.yaml` must
- [x] be approved by 2 members of the OQS TSC
- [x] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [ ] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [ ] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [ ] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations

