### PR TITLE
Add h2parson to oqs-contributors

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -94,6 +94,7 @@ teams:
   - planetf1
   - zadlg
   - thomwiggers
+  - h2parson
 
 # Technical Steering Committee
 # https://github.com/open-quantum-safe/tsc/blob/main/README.md#members


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

Hayden Parson (@h2parson) is a co-op student at the University of Waterloo and will be contributing to OQS over the coming months. This adds Hayden to oqs-contributors and would give him "triage" rights in the org. Please let me know if another team would be a more suitable choice.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- As changes to the file `config.yaml` are particularly sensitive because they change GH permissions throughout the project, the following rules apply to PRs affecting this file -->

Unconditionally, changes to `config.yaml` must
- [ ] be approved by 2 members of the OQS TSC
- [ ] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [ ] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [ ] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [ ] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations

