### PR TITLE
chore: update permissions

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -279,6 +279,7 @@ repositories:
 
 - name: liboqs
   teams:
+    bots: admin
     oqs-admins: admin
     liboqs-maintainers: admin
     oqs-release-managers: maintain
@@ -286,7 +287,6 @@ repositories:
     liboqs-codeowners: write
     oqs-contributors: triage
     security-managers: read
-    bots: write
     tsc: read
   visibility: public
 


### PR DESCRIPTION
sort teams
update bots from write to admin to enable AWS benchmarking

This is to enable AWS benchmarking. As access to more repos is needed, this role will need to change. This is in support of [the work in this branch](https://github.com/open-quantum-safe/liboqs/tree/sw-benchmarks) by @SWilson4 

Unconditionally, changes to `config.yaml` must

- [ ] be approved by 2 members of the OQS TSC
- [x] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [x] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [x] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [x] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations

