### PR TITLE
Remove @SWilson4 from teams and TSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,18 @@ The role and responsibilities of the TSC are described in the [Technical Charter
 
 ## Members
 
-- Norman Ashley (Cisco)
+- Norman Ashley (Cisco) – OQS representative to PQCA TAC
 - Michael Baentsch (independent contributor)
 - Thomas Bailleux (independent contributor)
 - Vlad Gheorghiu (softwareQ Inc.)
 - Basil Hess (IBM Research) – TSC vice chair
 - Christian Paquin (Microsoft Research)
 - Douglas Stebila (University of Waterloo) – TSC chair
-- Spencer Wilson (University of Waterloo) – OQS representative to PQCA TAC
 
 ## Former Members
+
 - Brian Jarvis (AWS)
+- Spencer Wilson (University of Waterloo)
 
 ## Communication Channels
 

--- a/config.yaml
+++ b/config.yaml
@@ -19,8 +19,6 @@ teams:
 - name: minute-takers
   maintainers:
   - dstebila
-  members:
-  - SWilson4
 
 # Security managers
 - name: security-managers
@@ -31,12 +29,11 @@ teams:
   - bhess
   - brian-jarvis-aws
   - praveksharma
-  - SWilson4
 
 # access to Trail of Bits audit project board
 - name: trail-of-bits
   maintainers:
-  - SWilson4
+  - dstebila
   members:
   - fcasal
   - tob-scott-a
@@ -58,7 +55,6 @@ teams:
   members:
   - baentsch
   - praveksharma
-  - SWilson4
   - vsoftco
 # A sensible default for projects without a clear list of Committers.
 # Mirrors the old "core" team.
@@ -71,7 +67,6 @@ teams:
   - bhess
   - christianpaquin
   - praveksharma
-  - SWilson4
   - vsoftco
 # A sensible default for projects without a clear list of Contributors.
 # TODO: add/update per-project GOVERNANCE.md files and remove this team.
@@ -106,7 +101,6 @@ teams:
   - baentsch
   - bhess
   - christianpaquin
-  - SWilson4
   - zadlg
   - vsoftco
 
@@ -117,7 +111,6 @@ teams:
   - dstebila
   members:
   - baentsch
-  - SWilson4
 # liboqs Committers
 # https://github.com/open-quantum-safe/liboqs/blob/main/GOVERNANCE.md#committers-1
 - name: liboqs-committers
@@ -129,7 +122,6 @@ teams:
   - christianpaquin
   - Martyrshot
   - praveksharma
-  - SWilson4
   - vsoftco
 # liboqs CODEOWNERS
 # https://github.com/open-quantum-safe/liboqs/blob/main/.github/CODEOWNERS
@@ -145,7 +137,6 @@ teams:
   - cothan
   - Martyrshot
   - praveksharma
-  - SWilson4
 
 # oqs-provider Maintainers
 # https://github.com/open-quantum-safe/oqs-provider/blob/main/GOVERNANCE.md#maintainers-1
@@ -241,7 +232,6 @@ teams:
   - thomwiggers
   members:
   - dstebila
-  - SWilson4
   - vsoftco
 # liboqs-rust Release Managers
 # TODO: provide "source of truth"
@@ -252,7 +242,6 @@ teams:
   members:
   - dstebila
   - praveksharma
-  - SWilson4
   - vsoftco
 
 - name: liboqs-cupqc-maintainers


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Spencer has concluded his work at UWaterloo and will be moving on to a new job. This PR removes him from the TSC and the various Github permissions.

Thank you Spencer for all your work over the past 2+ years! Best wishes in your new job!

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- As changes to the file `config.yaml` are particularly sensitive because they change GH permissions throughout the project, the following rules apply to PRs affecting this file -->

Unconditionally, changes to `config.yaml` must
- [x] be approved by 2 members of the OQS TSC
- [x] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [x] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [x] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [x] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations

