### PR TITLE
[vote] Proposal for OQS Project Lifecycle stage

### DIFF
--- a/governance/project_lifecycle.md
+++ b/governance/project_lifecycle.md
@@ -1,0 +1,10 @@
+# OQS Project Lifecycle status
+
+*Approved by OQS Technical Steering Committee on TODO.*
+
+The Post-Quantum Cryptography Alliance [Project Lifecycle Policy](https://pqca.github.io/TAC/Processes/Project_Lifecycle.html) describes the stages for technical projects within the PQCA.
+
+The OQS Technical Steering Committee currently considers the Open Quantum Safe project to be at the "Labs Stage" on the "Research Projects" track. 
+
+We recognize that some organizations are relying on OQS in various applications and may be interested in seeing the project advance to the PQCA's Production track. We would welcome increased involvement to grow the contributor and maintainer base to support the efforts required to reach that stage.
+


### PR DESCRIPTION
This PR resolves [discussion #2191](https://github.com/orgs/open-quantum-safe/discussions/2191) on placing OQS within the PQCA's Project Lifecycle document. Based on the discussion in the most recent TSC meeting, the proposal is to set OQS at the "Labs Stage" within the "Research Projects" track, and include a statement welcoming contributors who want to see movement towards the "Production" track.

I will leave the PR as a draft for a couple of days to see if anyone wants to suggest any changes, then make it a normal PR and request review from TSC members as a vote. Once a majority excluding me has approved, it would be considered passed and I will merge it (updating with the date it passes).