### PR TITLE
Add Bruce to config.yml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,7 @@ teams:
   - bhess
   - brian-jarvis-aws
   - praveksharma
+  - xuganyu96
 
 # access to Trail of Bits audit project board
 - name: trail-of-bits
@@ -55,6 +56,7 @@ teams:
   members:
   - baentsch
   - praveksharma
+  - xuganyu96
   - vsoftco
 # A sensible default for projects without a clear list of Committers.
 # Mirrors the old "core" team.
@@ -67,6 +69,7 @@ teams:
   - bhess
   - christianpaquin
   - praveksharma
+  - xuganyu96
   - vsoftco
 # A sensible default for projects without a clear list of Contributors.
 # TODO: add/update per-project GOVERNANCE.md files and remove this team.
@@ -122,6 +125,7 @@ teams:
   - christianpaquin
   - Martyrshot
   - praveksharma
+  - xuganyu96
   - vsoftco
 # liboqs CODEOWNERS
 # https://github.com/open-quantum-safe/liboqs/blob/main/.github/CODEOWNERS
@@ -137,6 +141,7 @@ teams:
   - cothan
   - Martyrshot
   - praveksharma
+  - xuganyu96
 
 # oqs-provider Maintainers
 # https://github.com/open-quantum-safe/oqs-provider/blob/main/GOVERNANCE.md#maintainers-1
@@ -183,6 +188,7 @@ teams:
   - baentsch
   - geedo0
   - praveksharma
+  - xuganyu96
 
 # liboqs-cpp Maintainers
 # TODO: provide "source of truth"
@@ -242,6 +248,7 @@ teams:
   members:
   - dstebila
   - praveksharma
+  - xuganyu96
   - vsoftco
 
 - name: liboqs-cupqc-maintainers


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

Bruce, @xuganyu96, is a Research Associate at the University of Waterloo and will be working on OQS. This PR adds his GitHub account to config.yml to give him relevant permissions. 

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- As changes to the file `config.yaml` are particularly sensitive because they change GH permissions throughout the project, the following rules apply to PRs affecting this file -->

Unconditionally, changes to `config.yaml` must
- [ ] be approved by 2 members of the OQS TSC
- [ ] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [ ] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [ ] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [ ] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations

