### PR TITLE
[vote] Allow contributions to OQS-OpenSSH using upstream license

### DIFF
--- a/governance/approved_licenses.md
+++ b/governance/approved_licenses.md
@@ -9,3 +9,7 @@ This document records license exemptions approved by the OQS TSC.
 ### OQS-BoringSSL
 
 Contributions to the repository [open-quantum-safe/boringssl](https://github.com/open-quantum-safe/boringssl/) can be made using the [LICENSE file included in that repository](https://github.com/open-quantum-safe/boringssl/blob/master/LICENSE).
+
+### OQS-OpenSSH
+
+Contributions to the repository [open-quantum-safe/openssh](https://github.com/open-quantum-safe/openssh/) can be made using the [LICENCE file included in that repository](https://github.com/open-quantum-safe/openssh/blob/OQS-v10/LICENCE).


### PR DESCRIPTION
This permits contributions to be made to OQS's openssh repository using the original OpenSSH license. This enables a smooth procedure for merging commits from upstream. This would have facilitated https://github.com/open-quantum-safe/openssh/pull/181 without requiring an extra DCO sign-off on the commits being merged from upstream.

Once a majority excluding me (4 out of 6) has approved, it would be considered passed and I will merge it.