### PR TITLE
[vote] Remove Thomas Bailleux (zadlg) from TSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The role and responsibilities of the TSC are described in the [Technical Charter
 
 - Norman Ashley (Cisco) – OQS representative to PQCA TAC
 - Michael Baentsch (independent contributor)
-- Thomas Bailleux (independent contributor)
 - Vlad Gheorghiu (softwareQ Inc.)
 - Basil Hess (IBM Research) – TSC vice chair
 - Christian Paquin (Microsoft Research)
@@ -28,6 +27,7 @@ The role and responsibilities of the TSC are described in the [Technical Charter
 
 - Brian Jarvis (AWS)
 - Spencer Wilson (University of Waterloo)
+- Thomas Bailleux (independent contributor)
 
 ## Communication Channels
 

--- a/config.yaml
+++ b/config.yaml
@@ -104,7 +104,6 @@ teams:
   - baentsch
   - bhess
   - christianpaquin
-  - zadlg
   - vsoftco
 
 # liboqs Maintainers


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
I've recently spoken with Thomas Bailleux @zadlg, and he needs to devote most of his time to his new company, so won't be able to continue on the OQS Technical Steering Committee for now. He's offered to step down, but says he is still eager to contribute to the security of OQS. Thanks very much, Thomas, for helping with OQS including OQS Provider over the past few years!  

This PR moves Thomas to the list of past TSC members and removes him from the TSC team in the Github configuration; I've kept him on the other teams he's listed on (e.g., oqs-provider-committers) as that's a separate matter.

Once a majority (4 out of 7, including me as chair) has approved, it would be considered passed and I will merge it.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- As changes to the file `config.yaml` are particularly sensitive because they change GH permissions throughout the project, the following rules apply to PRs affecting this file -->

Unconditionally, changes to `config.yaml` must
- [ ] be approved by 2 members of the OQS TSC
- [ ] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [ ] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [ ] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [ ] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations

