### PR TITLE
[vote] Add Rodrigo Martín as TSC co-chair / future chair

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ The role and responsibilities of the TSC are described in the [Technical Charter
 - Norman Ashley (Cisco) – OQS representative to PQCA TAC
 - Michael Baentsch (independent contributor)
 - Vlad Gheorghiu (softwareQ Inc.)
-- Basil Hess (IBM Research) – TSC vice chair, OQS liasion to PQ Code Package
+- Basil Hess (IBM Research) – OQS liasion to PQ Code Package
+- Rodrigo Martín (Indra) - TSC co-chair (until August 31, 2026, then sole chair)
 - Christian Paquin (Microsoft Research)
-- Douglas Stebila (University of Waterloo) – TSC chair
+- Douglas Stebila (University of Waterloo) – TSC co-chair (until August 31, 2026)
 
 ## Former Members
 
@@ -39,8 +40,6 @@ The TSC holds regular meetings every 5 weeks, alternating between 10am and 12:30
 
 Upcoming meetings:
 
-- Tuesday February 17, 2026, at 10:00am US Eastern time: [agenda](2026-02-17/agenda.md)
-- Tuesday March 24, 2026, at 12:30pm US Eastern time
 - Tuesday April 28, 2026, at 10:00am US Eastern time
 - Tuesday June 2, 2026, at 12:30pm US Eastern time
 - Tuesday July 7, 2026, at 10:00am US Eastern time

--- a/config.yaml
+++ b/config.yaml
@@ -99,6 +99,7 @@ teams:
 - name: tsc
   maintainers:
   - dstebila
+  - RodriM11
   members:
   - ashman-p
   - baentsch


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Based on the nomination in #246, this PR would appoint Rodrigo Martín to the OQS Technical Steering Committee as a member and co-chair; he would serve as co-chair with me until the end of August 2026, and then would take over as sole chair for a term through end of April 2026 (1 year from now-ish).

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Fixes #246.

<!-- As changes to the file `config.yaml` are particularly sensitive because they change GH permissions throughout the project, the following rules apply to PRs affecting this file -->

Unconditionally, changes to `config.yaml` must
- [ ] be approved by 2 members of the OQS TSC
- [ ] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [ ] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [ ] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [ ] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations


