### PR TITLE
Include Rodrigo in oqs-maintainers and oqs-committers teams

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,6 +48,7 @@ teams:
   members:
   - baentsch
   - vsoftco
+  - RodriM11
 # A sensible default for projects without a clear list of Release Managers.
 # TODO: add/update per-project GOVERNANCE.md files and remove this team.
 - name: oqs-release-managers
@@ -70,6 +71,7 @@ teams:
   - christianpaquin
   - xuganyu96
   - vsoftco
+  - RodriM11
 # A sensible default for projects without a clear list of Contributors.
 # TODO: add/update per-project GOVERNANCE.md files and remove this team.
 - name: oqs-contributors


### PR DESCRIPTION
Add @RodriM11 to `oqs-committers` and `oqs-maintainers` teams.

Unconditionally, changes to `config.yaml` must
- [ ] be approved by 2 members of the OQS TSC
- [ ] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [ ] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [ ] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [ ] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations

