### PR TITLE
add jplomas to ci-containers committers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -397,6 +397,7 @@ repositories:
     oqs-maintainers: admin
     oqs-release-managers: maintain
     oqs-committers: write
+    jplomas: write
     oqs-contributors: triage
     security-managers: read
     bots: write

--- a/config.yaml
+++ b/config.yaml
@@ -391,13 +391,20 @@ repositories:
     tsc: read
   visibility: public
 
+# ci-container Committers
+- name: ci-container-committers
+  maintainers:
+  - baentsch
+  members:
+  - jplomas
+
 - name: ci-containers
   teams:
     oqs-admins: admin
     oqs-maintainers: admin
     oqs-release-managers: maintain
     oqs-committers: write
-    jplomas: write
+    ci-container-committers: write
     oqs-contributors: triage
     security-managers: read
     bots: write

--- a/config.yaml
+++ b/config.yaml
@@ -279,6 +279,14 @@ teams:
   maintainers:
   - ktufekcic
 
+# ci-containers Committers
+# TODO: provide "source of truth"
+- name: ci-containers-committers
+  maintainers:
+  - baentsch
+  members:
+  - jplomas
+
 repositories:
 - name: .github
   teams:
@@ -391,20 +399,13 @@ repositories:
     tsc: read
   visibility: public
 
-# ci-container Committers
-- name: ci-container-committers
-  maintainers:
-  - baentsch
-  members:
-  - jplomas
-
 - name: ci-containers
   teams:
     oqs-admins: admin
     oqs-maintainers: admin
     oqs-release-managers: maintain
     oqs-committers: write
-    ci-container-committers: write
+    ci-containers-committers: write
     oqs-contributors: triage
     security-managers: read
     bots: write


### PR DESCRIPTION
@jplomas contributes to ci-containers and should have write permission to do so effectively, e.g., update PRs. Personal handle used as there is no ci-containers-committers group just yet.

Unconditionally, changes to `config.yaml` must
- [ ] be approved by 2 members of the OQS TSC
- [ ] not violate permissions documented in GOVERNANCE.md files for sub projects where such files exist

The following goals apply to changes to the file `config.yaml` with exceptions possible, as long as the rationale for the exception is documented by comments in the file:
- [ ] all sub projects should be treated identically wrt roles & responsibilities as per the detailed list below
- [ ] teams/team designations are to be used wherever possible; using personal GH handles should only be used in team definitions
- [ ] Admin changes to the file must be documented by comments as to the rationale of the change

All the following conditions hold for permissions set in `config.yaml`:
-    sub project maintainers have admin rights on the sub projects
-    OQS and sub project release managers have maintainer rights on the sub projects but can themselves set/reset branch protection rules limiting write access to sensitive branches
-    sub project committers have write rights on all branches of the sub projects but can request branch protection rules limiting this
-    sub project contributors (incl. code owners) have write rights on all branches except main on those sub projects
-    OQS and sub project triage actors have triage rights on all branches of the sub projects
-    OQS maintainers and LF admins have admin rights on the organization (e.g., org-wide secret management) as well as maintenance rights on the team configurations

