### PR TITLE
Add agenda for TSC Meeting 11/08/2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ The TSC holds regular meetings every 5 weeks, alternating between 10am and 12:30
 
 Upcoming meetings:
 
-- Tuesday July 7, 2026, at 10:00am US Eastern time
 - Tuesday August 11, 2026, at 12:30pm US Eastern time
 - Tuesday September 15, 2026, at 10:00am US Eastern time
 - Tuesday October 20, 2026, at 12:30pm US Eastern time

--- a/meetings/2026-08-11/agenda.md
+++ b/meetings/2026-08-11/agenda.md
@@ -1,0 +1,29 @@
+# OQS Technical Steering – 2026-08-11 – agenda
+
+## Meeting information
+
+**Date and time:** Tuesday, August 11, 2026, [16:30-17:30 UTC / 9:30-10:30 US Pacific / 12:30-13:30 US Eastern / 17:30-18:30 Central European](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20260324T1230&p1=1203)
+
+**Location:** [Zoom](https://zoom-lfx.platform.linuxfoundation.org/meetings/pqca?view=week)
+
+Information about the TSC (members, roles and responsibilities, charter) is available on Github at [https://github.com/open-quantum-safe/tsc](https://github.com/open-quantum-safe/tsc)
+
+## Agenda
+
+1. Introduction (Rodrigo)
+2. Approve agenda (Rodrigo)
+3. Review [action items from previous meeting](https://github.com/open-quantum-safe/tsc/blob/main/meetings/2026-07-07/minutes.md) (Douglas)
+    - [Update CODEOWNERS in liboqs to establish a responsible maintainer for each algorithm and update GOVERNANCE file with current maintainers/committers](https://github.com/open-quantum-safe/liboqs/pull/2410)
+    - [Security tracking report and appropriate security documentation update](https://github.com/open-quantum-safe/tsc/blob/main/meetings/2026-07-07/minutes.md)
+4. OQS Q2 Health report discussion (Rodrigo)
+    - Actions to be taken
+    - Expand it to other subprojects?
+5. Discussion on Classic McEliece inclusion (Rodrigo)
+6. Round 3 on-ramp (Douglas)
+    - Update on efforts
+    - Planification for September
+7. Reports (Douglas)
+    - PQCA TAC (Norm)
+    - PQ Code Package (Basil)
+    - PQCA general / Outreach and Education committee (Hart)
+8. Other business (Douglas)

--- a/meetings/2026-08-11/agenda.md
+++ b/meetings/2026-08-11/agenda.md
@@ -18,7 +18,7 @@ Information about the TSC (members, roles and responsibilities, charter) is avai
 4. OQS Q2 Health report discussion (Rodrigo)
     - Actions to be taken
     - Expand it to other subprojects?
-5. Discussion on Classic McEliece inclusion (Rodrigo)
+5. Discussion on ["What to do with subprojects which lose their last maintainer?"](https://github.com/open-quantum-safe/tsc/discussions/221) (Rodrigo)
 6. Round 3 on-ramp (Douglas)
     - Update on efforts
     - Planification for September

--- a/meetings/index.md
+++ b/meetings/index.md
@@ -29,7 +29,7 @@ Everyone, regardless of membership within the TSC itself, is welcome to attend. 
 - 2026-04-28: [agenda](2026-04-28/agenda.md) / [minutes](2026-04-28/minutes.md)
 - 2026-06-02: [agenda](2026-06-02/agenda.md) / [minutes](2026-06-02/minutes.md)
 - 2026-07-07: [agenda](2026-07-07/agenda.md) / [minutes](2026-07-07/minutes.md)
-- 2026-08-11: [agenda](2026-07-07/agenda.md)
+- 2026-08-11: [agenda](2026-08-11/agenda.md)
 
 ## Upcoming meetings
 

--- a/meetings/index.md
+++ b/meetings/index.md
@@ -28,13 +28,13 @@ Everyone, regardless of membership within the TSC itself, is welcome to attend. 
 - 2026-03-24: [agenda](2026-03-24/agenda.md) / [minutes](2026-03-24/minutes.md)
 - 2026-04-28: [agenda](2026-04-28/agenda.md) / [minutes](2026-04-28/minutes.md)
 - 2026-06-02: [agenda](2026-06-02/agenda.md) / [minutes](2026-06-02/minutes.md)
-- 2026-07-07: [agenda](2026-07-07/agenda.md)
+- 2026-07-07: [agenda](2026-07-07/agenda.md) / [minutes](2026-07-07/minutes.md)
+- 2026-08-11: [agenda](2026-07-07/agenda.md)
 
 ## Upcoming meetings
 
 Upcoming meetings:
 
-- Tuesday July 7, 2026, at 10:00am US Eastern time
 - Tuesday August 11, 2026, at 12:30pm US Eastern time
 - Tuesday September 15, 2026, at 10:00am US Eastern time
 - Tuesday October 20, 2026, at 12:30pm US Eastern time


### PR DESCRIPTION
This PR includes the proposed agenda for next week's TSC meeting. As agreed, this PR will remain open until Monday August 10th, for members to be able to discuss the agenda and provide inputs. 

On Monday, all these inputs will be taken into account to publish the final agenda for the TSC meeting.

Note that, based on the limited time of the meeting, not all open topics are part of this TSC meeting. Some issues to be discussed at the next TSC meeting include: 

- How to handle subprojects with no active maintenance: https://github.com/open-quantum-safe/tsc/discussions/221
- Proposals for backlog efficiency: https://github.com/open-quantum-safe/tsc/discussions/321

