### PR TITLE
Update chair and vice-chair information as of September 1st, 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The role and responsibilities of the TSC are described in the [Technical Charter
 - Michael Baentsch (independent contributor)
 - Vlad Gheorghiu (softwareQ Inc.)
 - Basil Hess (IBM Research) – OQS liasion to PQ Code Package
-- Rodrigo Martín (Indra) - TSC co-chair (until August 31, 2026, then sole chair)
+- Rodrigo Martín (Indra) – TSC chair
 - Christian Paquin (Microsoft Research)
-- Douglas Stebila (University of Waterloo) – TSC co-chair (until August 31, 2026, then vice-chair)
+- Douglas Stebila (University of Waterloo) – TSC vice-chair
 
 ## Former Members
 


### PR DESCRIPTION
As per https://github.com/open-quantum-safe/tsc/pull/267 and https://github.com/open-quantum-safe/tsc/pull/315, this PR updates the chair and vice-chair information as of September 1st, 2026.

